### PR TITLE
v3.2.1

### DIFF
--- a/amzpayments.php
+++ b/amzpayments.php
@@ -105,6 +105,8 @@ class AmzPayments extends PaymentModule
     public $preselect_create_account = 0;
     
     public $force_account_creation = 0;
+        
+    public $clear_cache = 1;
     
     public $hide_login_btns = 0;
     
@@ -160,6 +162,7 @@ class AmzPayments extends PaymentModule
         'send_mails_on_decline' => 'SEND_MAILS_ON_DECLINE',
         'preselect_create_account' => 'PRESELECT_CREATE_ACCOUNT',
         'force_account_creation' => 'FORCE_ACCOUNT_CREATION',
+        'clear_cache' => 'AMZ_CLEAR_CACHE',
         'hide_login_btns' => 'AMZ_HIDE_LOGIN_BTNS',
         'product_page_checkout' => 'AMZ_PRODUCT_PAGE_CHECKOUT',
         'promo_header' => 'AMZ_PROMO_HEADER',
@@ -174,7 +177,7 @@ class AmzPayments extends PaymentModule
     {
         $this->name = 'amzpayments';
         $this->tab = 'payments_gateways';
-        $this->version = '3.2.01';
+        $this->version = '3.2.1';
         $this->author = 'patworx multimedia GmbH';
         $this->need_instance = 1;
         
@@ -352,7 +355,7 @@ class AmzPayments extends PaymentModule
         Configuration::updateValue('REGION', $this->getDefaultModuleRegion());
         Configuration::updateValue('BUTTON_SIZE', 'medium');
         Configuration::updateValue('BUTTON_SIZE_LPA', 'medium');
-        Configuration::updateValue('TEMPLATE_VARIANT_BS', true);
+        Configuration::updateValue('AMZ_CLEAR_CACHE', true);
         Configuration::updateValue('IPN_STATUS', true);
         Configuration::updateValue('AMZ_HIDE_LOGIN_BTNS', false);
         Configuration::updateValue('AMZ_PROMO_HEADER', false);
@@ -577,7 +580,7 @@ class AmzPayments extends PaymentModule
     
     protected function getPossibleRegionEntries()
     {
-        return 'DE, UK, US, FR, IT, ES, JP';
+        return 'DE, AT, UK, US, FR, IT, ES, JP';
     }
     
     protected function getCronURL()
@@ -612,6 +615,12 @@ class AmzPayments extends PaymentModule
         }
     }
     
+    protected function getDomainForWhitelist()
+    {
+        $main_url = str_replace(array('http://', 'https://'), '', $this->context->link->getModuleLink('amzpayments', 'ipn', array()));
+        return 'https://' . Tools::substr($main_url, 0, Tools::strpos($main_url, '/'));
+    }
+    
     public function getConfigFormValues()
     {
         $return = array();
@@ -620,6 +629,13 @@ class AmzPayments extends PaymentModule
         }
         $return = $this->addDisabledCarrierOptions($return);
         return $return;
+    }
+    
+    public function getConfigFormValuesForDebug()
+    {
+        $vars = $this->getConfigFormValues();
+        unset($vars['SECRET_KEY']);
+        return $vars;
     }
     
     public function getConfigForm()
@@ -666,6 +682,10 @@ class AmzPayments extends PaymentModule
                                 array(
                                     'id_region' => 'JP',
                                     'name' => $this->l('Japan')
+                                ),
+                                array(
+                                    'id_region' => 'AT',
+                                    'name' => $this->l('Austria')
                                 ),
                             ),
                             'id' => 'id_region',
@@ -1114,6 +1134,25 @@ class AmzPayments extends PaymentModule
                         ),
                     ),
                     array(
+                        'type' => 'switch',
+                        'label' => $this->l('Clear cache automatically after saving'),
+                        'name' => 'AMZ_CLEAR_CACHE',
+                        'hint' => $this->l('Clearing cache is recommended after an update or a change in configuration.'),
+                        'is_bool' => true,
+                        'values' => array(
+                            array(
+                                'id' => 'active_on_clear_cache',
+                                'value' => true,
+                                'label' => $this->l('Enabled')
+                            ),
+                            array(
+                                'id' => 'active_off_clear_cache',
+                                'value' => '0',
+                                'label' => $this->l('Disabled')
+                            )
+                        )
+                    ),
+                    array(
                         'col' => 3,
                         'type' => 'select',
                         'prefix' => '<i class="icon icon-tag"></i>',
@@ -1433,9 +1472,11 @@ class AmzPayments extends PaymentModule
     
     public function getContent()
     {
+        $this->context->smarty->assign('display_cache_hint', false);
         if (Tools::getValue('resetDefault') == 'true') {
             $this->resetDefaultSettings();
             $this->context->smarty->assign('after_reset', '1');
+            $this->context->smarty->assign('display_cache_hint', true);
         }
         if (Tools::getValue('getLog') == 'true') {
             AmazonPaymentsLogHelper::generateAndSendLogfile($this);
@@ -1452,7 +1493,14 @@ class AmzPayments extends PaymentModule
                 $this->context->smarty->assign(array('postErrors' => $this->_postErrors));
             }
             if (count($this->_postSuccess)) {
+                $this->context->smarty->assign('display_cache_hint', true);
                 $this->context->smarty->assign(array('postSuccess' => $this->_postSuccess));
+                if (Configuration::get('AMZ_CLEAR_CACHE')) {
+                    Tools::clearSmartyCache();
+                    Tools::clearXMLCache();
+                    Media::clearCache();
+                    Tools::generateIndex();
+                }
             }
         }
         
@@ -1482,7 +1530,7 @@ class AmzPayments extends PaymentModule
         $this->context->smarty->assign('current_version', $this->version);
         $this->context->smarty->assign('allowed_return_url_1', $this->getAllowedReturnUrls(1));
         $this->context->smarty->assign('allowed_return_url_2', $this->getAllowedReturnUrls(2));
-        $this->context->smarty->assign('allowed_js_origins', $this->getBaseLink(null, true));
+        $this->context->smarty->assign('allowed_js_origins', $this->getDomainForWhitelist());
         $this->context->smarty->assign('base_url', $this->getBaseLink());
         $this->context->smarty->assign('language_code', $this->context->language->iso_code);
         $this->context->smarty->assign('log_url', $this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name . '&token=' . Tools::getAdminTokenLite('AdminModules') . '&getLog=true');
@@ -1581,7 +1629,7 @@ class AmzPayments extends PaymentModule
             'locale' =>  $this->getLocalCodeForSimplePath(),
             'loginRedirectURLs_1' => $this->getAllowedReturnUrls(1),
             'loginRedirectURLs_2' => $this->getAllowedReturnUrls(2),
-            'allowedLoginDomains' => $this->getBaseLink(null, true),
+            'allowedLoginDomains' => $this->getDomainForWhitelist(),
             'storeDescription' => Configuration::get('PS_SHOP_NAME'),
             'language' => $this->getLanguageCodeForSimplePath(),
             'returnMethod' => 'GET',
@@ -1642,7 +1690,7 @@ class AmzPayments extends PaymentModule
     
     public function getRegionalCodeForURL()
     {
-        if (in_array(Tools::strtolower($this->region), array('de', 'fr', 'it', 'es'))) {
+        if (in_array(Tools::strtolower($this->region), array('de', 'at', 'fr', 'it', 'es'))) {
             return 'de';
         } elseif (Tools::strtolower($this->region) == 'uk') {
             return 'uk';
@@ -1670,6 +1718,8 @@ class AmzPayments extends PaymentModule
             return 'ml_es_ap_np_ba_spli_xx_xx_xx_pre';
         } elseif (Tools::strtolower($this->region) == 'it') {
             return 'ml_it_ap_np_ba_spli_xx_xx_xx_pre';
+        } elseif (Tools::strtolower($this->region) == 'at') {
+            return 'ml_at_ap_np_ba_spli_xx_xx_xx_pre';
         }
         return 'ml_de_ap_np_ba_spli_xx_xx_xx_pre';
     }
@@ -1692,7 +1742,7 @@ class AmzPayments extends PaymentModule
     public function getButtonURL()
     {
         if ($this->environment == 'SANDBOX') {
-            if (in_array(Tools::strtolower($this->region), array('de', 'fr', 'it', 'es'))) {
+            if (in_array(Tools::strtolower($this->region), array('de', 'at', 'fr', 'it', 'es'))) {
                 return 'https://payments-sandbox.amazon.de/gp/widgets/button';
             } elseif (Tools::strtolower($this->region) == 'uk') {
                 return 'https://payments-sandbox.amazon.co.uk/gp/widgets/button';
@@ -1702,7 +1752,7 @@ class AmzPayments extends PaymentModule
                 return 'https://payments-sandbox.amazon.co.jp/gp/widgets/button';
             }
         } else {
-            if (in_array(Tools::strtolower($this->region), array('de', 'fr', 'it', 'es'))) {
+            if (in_array(Tools::strtolower($this->region), array('de', 'at', 'fr', 'it', 'es'))) {
                 return 'https://payments.amazon.de/gp/widgets/button';
             } elseif (Tools::strtolower($this->region) == 'uk') {
                 return 'https://payments.amazon.co.uk/gp/widgets/button';
@@ -1717,7 +1767,7 @@ class AmzPayments extends PaymentModule
     public function getLpaApiUrl()
     {
         if ($this->environment == 'SANDBOX') {
-            if (in_array(Tools::strtolower($this->region), array('de', 'fr', 'it', 'es'))) {
+            if (in_array(Tools::strtolower($this->region), array('de', 'at', 'fr', 'it', 'es'))) {
                 return 'https://api.sandbox.amazon.de';
             } elseif (Tools::strtolower($this->region) == 'uk') {
                 return 'https://api.sandbox.amazon.co.uk';
@@ -1727,7 +1777,7 @@ class AmzPayments extends PaymentModule
                 return 'https://api-sandbox.amazon.co.jp';
             }
         } else {
-            if (in_array(Tools::strtolower($this->region), array('de', 'fr', 'it', 'es'))) {
+            if (in_array(Tools::strtolower($this->region), array('de', 'at', 'fr', 'it', 'es'))) {
                 return 'https://api.amazon.de';
             } elseif (Tools::strtolower($this->region) == 'uk') {
                 return 'https://api.amazon.co.uk';
@@ -2020,6 +2070,8 @@ class AmzPayments extends PaymentModule
         
         if (Tools::strtolower($this->region) == 'de' && Tools::strtoupper($currency->iso_code) == 'EUR') {
             return true;
+        } elseif (Tools::strtolower($this->region) == 'at' && Tools::strtoupper($currency->iso_code) == 'EUR') {
+            return true;
         } elseif (Tools::strtolower($this->region) == 'fr' && Tools::strtoupper($currency->iso_code) == 'EUR') {
             return true;
         } elseif (Tools::strtolower($this->region) == 'it' && Tools::strtoupper($currency->iso_code) == 'EUR') {
@@ -2172,7 +2224,8 @@ class AmzPayments extends PaymentModule
         }
         
         $logout_str = '';
-        if ($this->context->controller->php_self == 'guest-tracking') {
+        if ($this->context->controller->php_self == 'guest-tracking' || isset($this->context->cookie->amz_logout)) {
+            unset($this->context->cookie->amz_logout);
             if ($this->lpa_mode != 'pay') {
                 $logout_str .= '<script type="text/javascript"> amazonLogout(); </script>';
             }
@@ -3051,6 +3104,10 @@ class AmzPayments extends PaymentModule
                 'light' => array('header' => 'https://m.media-amazon.com/images/G/01/EPSDocumentation/AmazonPay/Banners/DE/DELightGrey900x60.jpg', 'product' => 'https://m.media-amazon.com/images/G/01/EPSDocumentation/AmazonPay/Banners/DE/DELightGrey300x60.jpg', 'footer' => 'https://m.media-amazon.com/images/G/01/EPSDocumentation/AmazonPay/Banners/DE/DELightGrey230x60.jpg'),
                 'dark' => array('header' => 'https://m.media-amazon.com/images/G/01/EPSDocumentation/AmazonPay/Banners/DE/DEDarkGrey900x60.jpg', 'product' => 'https://m.media-amazon.com/images/G/01/EPSDocumentation/AmazonPay/Banners/DE/DEDarkGrey300x60.jpg', 'footer' => 'https://m.media-amazon.com/images/G/01/EPSDocumentation/AmazonPay/Banners/DE/DEDarkGrey230x60.jpg')
             ),
+            'at' => array(
+                'light' => array('header' => 'https://m.media-amazon.com/images/G/01/EPSDocumentation/AmazonPay/Banners/DE/DELightGrey900x60.jpg', 'product' => 'https://m.media-amazon.com/images/G/01/EPSDocumentation/AmazonPay/Banners/DE/DELightGrey300x60.jpg', 'footer' => 'https://m.media-amazon.com/images/G/01/EPSDocumentation/AmazonPay/Banners/DE/DELightGrey230x60.jpg'),
+                'dark' => array('header' => 'https://m.media-amazon.com/images/G/01/EPSDocumentation/AmazonPay/Banners/DE/DEDarkGrey900x60.jpg', 'product' => 'https://m.media-amazon.com/images/G/01/EPSDocumentation/AmazonPay/Banners/DE/DEDarkGrey300x60.jpg', 'footer' => 'https://m.media-amazon.com/images/G/01/EPSDocumentation/AmazonPay/Banners/DE/DEDarkGrey230x60.jpg')
+            ),
             'es' => array(
                 'light' => array('header' => 'https://m.media-amazon.com/images/G/01/EPSDocumentation/AmazonPay/Banners/ES/ESLightGrey900x60.jpg', 'product' => 'https://m.media-amazon.com/images/G/01/EPSDocumentation/AmazonPay/Banners/ES/ESLightGrey300x60.jpg', 'footer' => 'https://m.media-amazon.com/images/G/01/EPSDocumentation/AmazonPay/Banners/ES/ESLightGrey230x60.jpg'),
                 'dark' => array('header' => 'https://m.media-amazon.com/images/G/01/EPSDocumentation/AmazonPay/Banners/ES/ESDarkGrey900x60.jpg', 'product' => 'https://m.media-amazon.com/images/G/01/EPSDocumentation/AmazonPay/Banners/ES/ESDarkGrey300x60.jpg', 'footer' => 'https://m.media-amazon.com/images/G/01/EPSDocumentation/AmazonPay/Banners/ES/ESDarkGrey230x60.jpg')
@@ -3071,6 +3128,8 @@ class AmzPayments extends PaymentModule
         switch ($this->context->language->iso_code) {
             case 'de':
                 return $banners['de'];
+            case 'at':
+                return $banners['at'];
             case 'us':
             case 'en':
                 return $banners['uk'];
@@ -3090,6 +3149,8 @@ class AmzPayments extends PaymentModule
         switch ($this->context->language->iso_code) {
             case 'de':
                 return 'DE';
+            case 'at':
+                return 'AT';
             case 'us':
                 return 'US';
             case 'en':

--- a/classes/AmazonPaymentsLogHelper.php
+++ b/classes/AmazonPaymentsLogHelper.php
@@ -30,7 +30,7 @@ class AmazonPaymentsLogHelper
             'PrestaShop URL SSL' => _PS_BASE_URL_SSL_,
             'SSL State' => Configuration::get('PS_SSL_ENABLED') ? '1' : '0',
             'Plugin Version' => $amzpayments->version,
-            'Configuration options' => $amzpayments->getConfigFormValues(),
+            'Configuration options' => $amzpayments->getConfigFormValuesForDebug(),
             'SimplePathData' => $amzpayments->getSimplePathData(),
         );
                 

--- a/classes/AmazonTransactions.php
+++ b/classes/AmazonTransactions.php
@@ -24,14 +24,18 @@ class AmazonTransactions
 
     public static function handleError($response)
     {
+        $amz_paymentsObj = new AmzPayments();
         try {
             $responsearray = $response->toArray();
             if (isset($responsearray['Error']['Code']) && isset($responsearray['Error']['Message'])) {
+                $amz_paymentsObj->exceptionLog($responsearray, 'ERROR: ' . $responsearray['Error']['Code'] . ': ' . $responsearray['Error']['Message']);
                 return 'ERROR: ' . $responsearray['Error']['Code'] . ': ' . $responsearray['Error']['Message'];
             } elseif (isset($responsearray['Error']['Code'])) {
+                $amz_paymentsObj->exceptionLog($responsearray, 'ERROR: ' . $responsearray['Error']['Code']);
                 return 'ERROR: ' . $responsearray['Error']['Code'];
             }
         } catch (Exception $e) {
+            $amz_paymentsObj->exceptionLog($e);
             return 'Unknown error';
         }
     }
@@ -80,13 +84,6 @@ class AmazonTransactions
         }
         
         $requestParameters['transaction_timeout'] = $timeout;
-        /*if ($amz_payments->provocation == 'hard_decline' && $amz_payments->environment == 'SANDBOX') {
-            $requestParameters['seller_authorization_note'] = '{"SandboxSimulation": {"State":"Declined", "ReasonCode":"AmazonRejected"}}';
-        }
-        if ($amz_payments->provocation == 'soft_decline' && $amz_payments->environment == 'SANDBOX') {
-            Context::getContext()->cookie->setHadErrorNowWallet = 1;
-            $requestParameters['seller_authorization_note'] = '{"SandboxSimulation": {"State":"Declined", "ReasonCode":"InvalidPaymentMethod", "PaymentMethodUpdateTimeInMins":2}}';
-        }*/
 
         $response = $service->authorize($requestParameters);
         $responsearray = $response->toArray();

--- a/controllers/front/addresswallet.php
+++ b/controllers/front/addresswallet.php
@@ -84,6 +84,12 @@ class AmzpaymentsAddresswalletModuleFrontController extends ModuleFrontControlle
         if (Tools::getValue('session') != '') {
             $this->context->cookie->amazon_id = Tools::getValue('session');
         }
+        if (Tools::getValue('amz')) {
+            $this->context->smarty->assign('amz_session', Tools::getValue('amz'));
+        }
+        if (isset($this->context->cookie->setHadErrorNowWallet) && $this->context->cookie->setHadErrorNowWallet == '1') {
+            $this->context->smarty->assign('widgetreadonly', true);
+        }
         $this->context->cart->id_address_delivery = null;
         $this->context->cart->id_address_invoice = null;
         parent::initContent();

--- a/controllers/front/processlogin.php
+++ b/controllers/front/processlogin.php
@@ -76,6 +76,7 @@ class AmzpaymentsProcessloginModuleFrontController extends ModuleFrontController
         parent::initContent();
         
         unset($this->context->cookie->amazon_id);
+        unset($this->context->cookie->setHadErrorNowWallet);
         
         $this->context->smarty->assign('toCheckout', Tools::getValue('toCheckout'));
         $this->context->smarty->assign('fromCheckout', Tools::getValue('fromCheckout'));

--- a/translations/GB.php
+++ b/translations/GB.php
@@ -99,6 +99,7 @@ $_MODULE['<{amzpayments}prestashop>amzpayments_5aa818b1473c50ce1b40bf66663182c6'
 $_MODULE['<{amzpayments}prestashop>amzpayments_d9d5eafae1a4bbddd5b81c4d6ca255d1'] = 'Your selected payment method has been declined. Please chose another one or use a different Amazon account.';
 $_MODULE['<{amzpayments}prestashop>amzpayments_3c1faed661d6b55c61cd4a05fd1b687e'] = 'Show Amazon Pay button on product page';
 $_MODULE['<{amzpayments}prestashop>amzpayments_15ad3e8d2603d8c92314a60a114fa038'] = 'Default: No';
+$_MODULE['<{amzpayments}prestashop>configuration_fa834776c3045f5610c85a9faffe5f65'] = 'Please note: if you use server side caching (for example in combination with nginx), remember to empty it after saving the configuration.';
 $_MODULE['<{amzpayments}prestashop>configuration_56b55033f747893cf02a5797707ee383'] = 'Make Amazon customers your customers';
 $_MODULE['<{amzpayments}prestashop>configuration_a7b8feea65558548dff1c84f2f8801ab'] = 'That\'s how it works:';
 $_MODULE['<{amzpayments}prestashop>configuration_5b1a8c5b0fd7e134325ee37f10abed53'] = 'Register for Amazon Pay and complete your account setup by upload your verification documents on Seller Central.*';
@@ -194,6 +195,8 @@ $_MODULE['<{amzpayments}prestashop>amzpayments_9a6393c36c052c03efe4a8c0f0fcc487'
 $_MODULE['<{amzpayments}prestashop>amzpayments_dfa76a928ca510e1bd3c837d78358489'] = 'Colour of the Amazon Checkout button';
 $_MODULE['<{amzpayments}prestashop>amzpayments_caf3a042a037c064b7513ed640c22f77'] = 'Grey';
 $_MODULE['<{amzpayments}prestashop>amzpayments_6deb26d36a88344bcd7f71914a086055'] = 'Template Bootstrap';
+$_MODULE['<{amzpayments}prestashop>amzpayments_4261cabf4d3eeefd16da5a582dbebd4e'] = 'Clear cache automatically after saving';
+$_MODULE['<{amzpayments}prestashop>amzpayments_3392b1700cb8affec0ce6fba2fff833d'] = 'Clearing cache is recommended after an update or a change in configuration.';
 $_MODULE['<{amzpayments}prestashop>amzpayments_a2af94a3e3857e4903cf97df11fd9440'] = 'Your selected payment method was rejected. Please choose an alternative method.';
 $_MODULE['<{amzpayments}prestashop>amzpayments_fa31ce6046882558f0637d428a96abeb'] = 'Create customer account.';
 $_MODULE['<{amzpayments}prestashop>amzpayments_9a1ff3881b92951d9663aaef38e8b637'] = 'You don\'t need to do anything. We create the account with the data of your current order.';

--- a/translations/de.php
+++ b/translations/de.php
@@ -99,6 +99,7 @@ $_MODULE['<{amzpayments}prestashop>amzpayments_5aa818b1473c50ce1b40bf66663182c6'
 $_MODULE['<{amzpayments}prestashop>amzpayments_a2af94a3e3857e4903cf97df11fd9440'] = 'Ihre gewählte Zahlungsmethode wurde abgelehnt. Bitte wählen Sie eine alternative Methode.';
 $_MODULE['<{amzpayments}prestashop>amzpayments_3c1faed661d6b55c61cd4a05fd1b687e'] = 'Amazon Pay Button auf Produktseite zeigen';
 $_MODULE['<{amzpayments}prestashop>amzpayments_15ad3e8d2603d8c92314a60a114fa038'] = 'Standard: Nein';
+$_MODULE['<{amzpayments}prestashop>configuration_fa834776c3045f5610c85a9faffe5f65'] = 'Bitte beachten Sie: sollten Sie serverseitiges Caching (z.B. in Verbindung mit nginx) nutzen, denken Sie daran diesen nach dem Speichern der Konfiguration zu leeren.';
 $_MODULE['<{amzpayments}prestashop>configuration_56b55033f747893cf02a5797707ee383'] = 'Machen Sie Amazon-Kunden zu Ihren Kunden';
 $_MODULE['<{amzpayments}prestashop>configuration_a7b8feea65558548dff1c84f2f8801ab'] = 'So funktioniert\'s';
 $_MODULE['<{amzpayments}prestashop>configuration_5b1a8c5b0fd7e134325ee37f10abed53'] = 'Registrieren Sie sich für Amazon Pay*. Loggen Sie sich nach der Registrierung in Seller Central ein, um die Accounteinrichtung abzuschließen.*';
@@ -190,6 +191,8 @@ $_MODULE['<{amzpayments}prestashop>embedded_payment_option_b060b34f618bd9d3e0bde
 $_MODULE['<{amzpayments}prestashop>payment_ed20689b0d8d53ec534166a88b67f259'] = 'Amazon Pay';
 $_MODULE['<{amzpayments}prestashop>payment_8811becbf523354e20e2017242326f70'] = '(Komfortabel mit Ihrem Amazon-Account bezahlen)';
 $_MODULE['<{amzpayments}prestashop>amzpayments_8667cecb1de0a963f560deab1b02523d'] = 'Login mit Amazon Komponenten im Frontend verbergen';
+$_MODULE['<{amzpayments}prestashop>amzpayments_4261cabf4d3eeefd16da5a582dbebd4e'] = 'Cache nach dem Speichern automatisch leeren';
+$_MODULE['<{amzpayments}prestashop>amzpayments_3392b1700cb8affec0ce6fba2fff833d'] = 'Den Cache leeren ist empfohlen nach einem Update oder Änderung der Konfiguration.';
 $_MODULE['<{amzpayments}prestashop>amzpayments_6deb26d36a88344bcd7f71914a086055'] = 'Template Bootstrap';
 $_MODULE['<{amzpayments}prestashop>amzpayments_7de64f538bdd7057ea1bbf5b46572d67'] = 'Bitte geben Sie die fehlenden Adressdaten ein';
 $_MODULE['<{amzpayments}prestashop>select_address_7de64f538bdd7057ea1bbf5b46572d67'] = 'Bitte geben Sie die fehlenden Adressdaten ein';

--- a/translations/en.php
+++ b/translations/en.php
@@ -99,6 +99,7 @@ $_MODULE['<{amzpayments}prestashop>amzpayments_5aa818b1473c50ce1b40bf66663182c6'
 $_MODULE['<{amzpayments}prestashop>amzpayments_d9d5eafae1a4bbddd5b81c4d6ca255d1'] = 'Your selected payment method has been declined. Please chose another one or use a different Amazon account.';
 $_MODULE['<{amzpayments}prestashop>amzpayments_3c1faed661d6b55c61cd4a05fd1b687e'] = 'Show Amazon Pay button on product page';
 $_MODULE['<{amzpayments}prestashop>amzpayments_15ad3e8d2603d8c92314a60a114fa038'] = 'Default: No';
+$_MODULE['<{amzpayments}prestashop>configuration_fa834776c3045f5610c85a9faffe5f65'] = 'Please note: if you use server side caching (for example in combination with nginx), remember to empty it after saving the configuration.';
 $_MODULE['<{amzpayments}prestashop>configuration_56b55033f747893cf02a5797707ee383'] = 'Make Amazon customers your customers';
 $_MODULE['<{amzpayments}prestashop>configuration_a7b8feea65558548dff1c84f2f8801ab'] = 'That\'s how it works:';
 $_MODULE['<{amzpayments}prestashop>configuration_5b1a8c5b0fd7e134325ee37f10abed53'] = 'Register for Amazon Pay and complete your account setup by upload your verification documents on Seller Central.*';
@@ -194,6 +195,8 @@ $_MODULE['<{amzpayments}prestashop>amzpayments_9a6393c36c052c03efe4a8c0f0fcc487'
 $_MODULE['<{amzpayments}prestashop>amzpayments_dfa76a928ca510e1bd3c837d78358489'] = 'Colour of the Amazon Checkout button';
 $_MODULE['<{amzpayments}prestashop>amzpayments_caf3a042a037c064b7513ed640c22f77'] = 'Grey';
 $_MODULE['<{amzpayments}prestashop>amzpayments_6deb26d36a88344bcd7f71914a086055'] = 'Template Bootstrap';
+$_MODULE['<{amzpayments}prestashop>amzpayments_4261cabf4d3eeefd16da5a582dbebd4e'] = 'Clear cache automatically after saving';
+$_MODULE['<{amzpayments}prestashop>amzpayments_3392b1700cb8affec0ce6fba2fff833d'] = 'Clearing cache is recommended after an update or a change in configuration.';
 $_MODULE['<{amzpayments}prestashop>amzpayments_a2af94a3e3857e4903cf97df11fd9440'] = 'Your selected payment method was rejected. Please choose an alternative method.';
 $_MODULE['<{amzpayments}prestashop>amzpayments_fa31ce6046882558f0637d428a96abeb'] = 'Create customer account.';
 $_MODULE['<{amzpayments}prestashop>amzpayments_9a1ff3881b92951d9663aaef38e8b637'] = 'You don\'t need to do anything. We create the account with the data of your current order.';

--- a/translations/es.php
+++ b/translations/es.php
@@ -53,6 +53,8 @@ $_MODULE['<{amzpayments}prestashop>amzpayments_f38911eda842056931cbcf497a2f8fe5'
 $_MODULE['<{amzpayments}prestashop>amzpayments_9d57203f843f48a4cbc5da56cd9eba9a'] = 'Estado del pedido después de captar el pago correctamente';
 $_MODULE['<{amzpayments}prestashop>amzpayments_1a357f75f77b4eaa734c35cc15fa4ca7'] = 'Estado rechazado';
 $_MODULE['<{amzpayments}prestashop>amzpayments_da7bc25895336d39dfb2603378728d86'] = 'Provocar errores (sólo Sandbox)';
+$_MODULE['<{amzpayments}prestashop>amzpayments_4261cabf4d3eeefd16da5a582dbebd4e'] = 'Borrar la caché automáticamente después de guardar los cambios';
+$_MODULE['<{amzpayments}prestashop>amzpayments_3392b1700cb8affec0ce6fba2fff833d'] = 'Se recomienda borrar la caché después de realizar una actualización o modificación de configuración.';
 $_MODULE['<{amzpayments}prestashop>amzpayments_6deb26d36a88344bcd7f71914a086055'] = 'Template Bootstrap';
 $_MODULE['<{amzpayments}prestashop>amzpayments_bafd7322c6e97d25b6299b5d6fe8920b'] = 'No';
 $_MODULE['<{amzpayments}prestashop>amzpayments_63d098bd60c469852c135349eb50c6ad'] = 'Rechazo definitivo';
@@ -165,6 +167,7 @@ $_MODULE['<{amzpayments}prestashop>confirmation_0db71da7150c27142eef9d22b843b4a9
 $_MODULE['<{amzpayments}prestashop>confirmation_64430ad2835be8ad60c59e7d44e4b0b1'] = 'nuestro Atención al cliente.';
 $_MODULE['<{amzpayments}prestashop>payment_ed20689b0d8d53ec534166a88b67f259'] = 'Pagar con Amazon';
 $_MODULE['<{amzpayments}prestashop>payment_8811becbf523354e20e2017242326f70'] = '(Pagos cómodos y seguros con tu cuenta de Amazon)';
+$_MODULE['<{amzpayments}prestashop>configuration_fa834776c3045f5610c85a9faffe5f65'] = 'Por favor, ten en cuenta que si estas usando el almacenamiento de caché del lado del servidor (server-side caching, por ejemplo, en combinación con nginx); recuerda borrarlo después de guardar la configuración.';
 $_MODULE['<{amzpayments}prestashop>configuration_56b55033f747893cf02a5797707ee383'] = 'Convierte a los clientes de Amazon en tus propios clientes de forma rápida y fácil';
 $_MODULE['<{amzpayments}prestashop>configuration_a7b8feea65558548dff1c84f2f8801ab'] = 'Así es como funciona:';
 $_MODULE['<{amzpayments}prestashop>configuration_5b1a8c5b0fd7e134325ee37f10abed53'] = 'Registra tu cuenta de Amazon Pay. Después de registrarte tendrás que iniciar sesión en Seller Central para completar la creación de tu cuenta.*';

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -53,6 +53,8 @@ $_MODULE['<{amzpayments}prestashop>amzpayments_f38911eda842056931cbcf497a2f8fe5'
 $_MODULE['<{amzpayments}prestashop>amzpayments_9d57203f843f48a4cbc5da56cd9eba9a'] = 'Etat de la commande après une saisie réussie';
 $_MODULE['<{amzpayments}prestashop>amzpayments_1a357f75f77b4eaa734c35cc15fa4ca7'] = 'Commande refusée';
 $_MODULE['<{amzpayments}prestashop>amzpayments_6deb26d36a88344bcd7f71914a086055'] = 'Template Bootstrap';
+$_MODULE['<{amzpayments}prestashop>amzpayments_4261cabf4d3eeefd16da5a582dbebd4e'] = 'Vider le cache automatiquement à la sauvegarde';
+$_MODULE['<{amzpayments}prestashop>amzpayments_3392b1700cb8affec0ce6fba2fff833d'] = 'Vider le cache est recommandée après une actualisation ou changement de la configuration.';
 $_MODULE['<{amzpayments}prestashop>amzpayments_da7bc25895336d39dfb2603378728d86'] = 'Provoquer des erreurs (Sandbox uniquement)';
 $_MODULE['<{amzpayments}prestashop>amzpayments_bafd7322c6e97d25b6299b5d6fe8920b'] = 'Non';
 $_MODULE['<{amzpayments}prestashop>amzpayments_63d098bd60c469852c135349eb50c6ad'] = 'Refus long';
@@ -165,6 +167,7 @@ $_MODULE['<{amzpayments}prestashop>confirmation_0db71da7150c27142eef9d22b843b4a9
 $_MODULE['<{amzpayments}prestashop>confirmation_64430ad2835be8ad60c59e7d44e4b0b1'] = 'service client.';
 $_MODULE['<{amzpayments}prestashop>payment_ed20689b0d8d53ec534166a88b67f259'] = 'Payez avec Amazon';
 $_MODULE['<{amzpayments}prestashop>payment_8811becbf523354e20e2017242326f70'] = '(Paiement sécurisé et pratique avec votre compte Amazon)';
+$_MODULE['<{amzpayments}prestashop>configuration_fa834776c3045f5610c85a9faffe5f65'] = 'Veuillez noter que si vous utilisez la mise en cache côté serveur (par exemple en combinaison avec nginx), il faudra la vider après avoir enregistré la configuration.';
 $_MODULE['<{amzpayments}prestashop>configuration_56b55033f747893cf02a5797707ee383'] = 'Faites des clients Amazon vos clients, simplement et rapidement ';
 $_MODULE['<{amzpayments}prestashop>configuration_a7b8feea65558548dff1c84f2f8801ab'] = 'Voici le detail:';
 $_MODULE['<{amzpayments}prestashop>configuration_5b1a8c5b0fd7e134325ee37f10abed53'] = 'Complétez notre formulaire d\'enregistrement en ligne et terminez la configuration de votre compte en téléchargeant vos documents de vérification sur Seller Central.*';
@@ -330,7 +333,7 @@ $_MODULE['<{amzpayments}prestashop>configuration_f82018792ad5426aa329cc2603d65d9
 $_MODULE['<{amzpayments}prestashop>configuration_58b01895bc2e40a3a368219d1da28647'] = 'Origines JavaScript autorisées:';
 $_MODULE['<{amzpayments}prestashop>configuration_f74c06c90e54eeb3ded436c3b6c9e59a'] = 'Copiez l’URL dans le Presse-papiers:';
 $_MODULE['<{amzpayments}prestashop>configuration_901e3e0bb8483a87d063147f5200db6a'] = 'Collez l’URL dans le champ [1]Origines JavaScript autorisées[/1]:';
-$_MODULE['<{amzpayments}prestashop>configuration_22d1bc2c741d34943f15181c2e28eedf'] = '%s. URL de renvoi autoriées';
+$_MODULE['<{amzpayments}prestashop>configuration_22d1bc2c741d34943f15181c2e28eedf'] = '%s. URL de renvoi autorisées';
 $_MODULE['<{amzpayments}prestashop>configuration_8ca1ea6f20571a0bca7bf554014dcea6'] = 'Collez le lien URL dans le champ [1]URL de renvoi autorisées[/1].';
 $_MODULE['<{amzpayments}prestashop>configuration_8e93d62695e066bd8632ee048a7ed3b2'] = 'Assurez-vous que votre compte Amazon Payments a été vérifié ';
 $_MODULE['<{amzpayments}prestashop>configuration_98621e2154a1a626306f04b1a964f756'] = 'Votre compte a été validé.';

--- a/translations/it.php
+++ b/translations/it.php
@@ -52,6 +52,8 @@ $_MODULE['<{amzpayments}prestashop>amzpayments_28c6194859e3104cfb02445b83efadc5'
 $_MODULE['<{amzpayments}prestashop>amzpayments_05033bc4d960e0f74efacd29dbfb91fd'] = 'subito dopo l’autorizzazione';
 $_MODULE['<{amzpayments}prestashop>amzpayments_f38911eda842056931cbcf497a2f8fe5'] = 'Stato ordine per acquisizione pagamento';
 $_MODULE['<{amzpayments}prestashop>amzpayments_9d57203f843f48a4cbc5da56cd9eba9a'] = 'Stato ordine dopo acquisizione completata';
+$_MODULE['<{amzpayments}prestashop>amzpayments_4261cabf4d3eeefd16da5a582dbebd4e'] = 'Svuotare la cache automaticamente dopo il salvataggio';
+$_MODULE['<{amzpayments}prestashop>amzpayments_3392b1700cb8affec0ce6fba2fff833d'] = 'Si raccomanda di svuotare la cache dopo un aggiornamento o un cambio di configurazione.';
 $_MODULE['<{amzpayments}prestashop>amzpayments_6deb26d36a88344bcd7f71914a086055'] = 'Template Bootstrap';
 $_MODULE['<{amzpayments}prestashop>amzpayments_da7bc25895336d39dfb2603378728d86'] = 'Provoca errori (solo Sandbox)';
 $_MODULE['<{amzpayments}prestashop>amzpayments_bafd7322c6e97d25b6299b5d6fe8920b'] = 'No';
@@ -102,6 +104,7 @@ $_MODULE['<{amzpayments}prestashop>amzpayments_a2af94a3e3857e4903cf97df11fd9440'
 $_MODULE['<{amzpayments}prestashop>amzpayments_3c1faed661d6b55c61cd4a05fd1b687e'] = 'Mostra il bottone Amazon Pay nella pagina del prodotto';
 $_MODULE['<{amzpayments}prestashop>amzpayments_15ad3e8d2603d8c92314a60a114fa038'] = 'Default: No';
 $_MODULE['<{amzpayments}prestashop>configuration_9e6d5afc084382d3eb41d205b0653215'] = 'È in corso la verifica della disponibilità di nuove versioni del modulo';
+$_MODULE['<{amzpayments}prestashop>configuration_fa834776c3045f5610c85a9faffe5f65'] = 'Importante: Se stai usando la cache lato server (ad esempio in combinazione con nginx), ricordati di svuotarla dopo aver salvato la configurazione.';
 $_MODULE['<{amzpayments}prestashop>configuration_19d04b594594d21dacab32ccf4feb5b6'] = 'Versione in uso:';
 $_MODULE['<{amzpayments}prestashop>configuration_6579d7f0af067b0aae4c40ab1b0334c2'] = 'Nuova versione:';
 $_MODULE['<{amzpayments}prestashop>configuration_dd8dd5f5ae81213cce452d234ab8d16b'] = 'Stai utilizzando la versione più aggiornata';

--- a/translations/us.php
+++ b/translations/us.php
@@ -99,6 +99,7 @@ $_MODULE['<{amzpayments}prestashop>amzpayments_5aa818b1473c50ce1b40bf66663182c6'
 $_MODULE['<{amzpayments}prestashop>amzpayments_d9d5eafae1a4bbddd5b81c4d6ca255d1'] = 'Your selected payment method has been declined. Please chose another one or use a different Amazon account.';
 $_MODULE['<{amzpayments}prestashop>amzpayments_3c1faed661d6b55c61cd4a05fd1b687e'] = 'Show Amazon Pay button on product page';
 $_MODULE['<{amzpayments}prestashop>amzpayments_15ad3e8d2603d8c92314a60a114fa038'] = 'Default: No';
+$_MODULE['<{amzpayments}prestashop>configuration_fa834776c3045f5610c85a9faffe5f65'] = 'Please note: if you use server side caching (for example in combination with nginx), remember to empty it after saving the configuration.';
 $_MODULE['<{amzpayments}prestashop>configuration_56b55033f747893cf02a5797707ee383'] = 'Make Amazon customers your customers';
 $_MODULE['<{amzpayments}prestashop>configuration_a7b8feea65558548dff1c84f2f8801ab'] = 'That\'s how it works:';
 $_MODULE['<{amzpayments}prestashop>configuration_5b1a8c5b0fd7e134325ee37f10abed53'] = 'Register for Amazon Pay and complete your account setup by upload your verification documents on Seller Central.*';
@@ -194,6 +195,8 @@ $_MODULE['<{amzpayments}prestashop>amzpayments_9a6393c36c052c03efe4a8c0f0fcc487'
 $_MODULE['<{amzpayments}prestashop>amzpayments_dfa76a928ca510e1bd3c837d78358489'] = 'Colour of the Amazon Checkout button';
 $_MODULE['<{amzpayments}prestashop>amzpayments_caf3a042a037c064b7513ed640c22f77'] = 'Grey';
 $_MODULE['<{amzpayments}prestashop>amzpayments_6deb26d36a88344bcd7f71914a086055'] = 'Template Bootstrap';
+$_MODULE['<{amzpayments}prestashop>amzpayments_4261cabf4d3eeefd16da5a582dbebd4e'] = 'Clear cache automatically after saving';
+$_MODULE['<{amzpayments}prestashop>amzpayments_3392b1700cb8affec0ce6fba2fff833d'] = 'Clearing cache is recommended after an update or a change in configuration.';
 $_MODULE['<{amzpayments}prestashop>amzpayments_a2af94a3e3857e4903cf97df11fd9440'] = 'Your selected payment method was rejected. Please choose an alternative method.';
 $_MODULE['<{amzpayments}prestashop>amzpayments_fa31ce6046882558f0637d428a96abeb'] = 'Create customer account.';
 $_MODULE['<{amzpayments}prestashop>amzpayments_9a1ff3881b92951d9663aaef38e8b637'] = 'You don\'t need to do anything. We create the account with the data of your current order.';

--- a/upgrade/upgrade-3.2.1.php
+++ b/upgrade/upgrade-3.2.1.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * 2013-2017 Amazon Advanced Payment APIs Modul
+ *
+ * for Support please visit www.patworx.de
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    patworx multimedia GmbH <service@patworx.de>
+ *  @copyright 2013-2017 patworx multimedia GmbH
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_3_2_1($module)
+{
+    Configuration::updateValue('AMZ_CLEAR_CACHE', true);
+    return true;
+}

--- a/vendor/PayWithAmazon/Regions.php
+++ b/vendor/PayWithAmazon/Regions.php
@@ -14,12 +14,14 @@ class Regions
     public $profileEndpointUrls = array('uk' => 'amazon.co.uk',
 					'us' => 'amazon.com',
 					'de' => 'amazon.de',
+                    'at' => 'amazon.de',
 					'fr' => 'amazon.de',
 					'it' => 'amazon.de',
 					'es' => 'amazon.de',
 					'jp' => 'amazon.co.jp');
     
     public $regionMappings = array('de' => 'eu',
+                   'at' => 'eu',
                    'fr' => 'eu',
                    'it' => 'eu',
                    'es' => 'eu',

--- a/views/templates/admin/configuration.tpl
+++ b/views/templates/admin/configuration.tpl
@@ -27,6 +27,11 @@
 		{l s='If you need help, please [1]contact our support[/1]' tags=['<a onclick="jQuery(\'#amztabs a[href=#amzcontactus]\').tab(\'show\');">'] mod='amzpayments'}
 	</div>
 {/if}
+{if $display_cache_hint}
+	<div class="alert alert-warning" role="alert">
+		{l s='Please note: if you use server side caching (for example in combination with nginx), remember to empty it after saving the configuration.' mod='amzpayments'}				
+	</div>				
+{/if}
 
 <form method="POST" action="https://payments-eu.amazon.com/register" target="_blank" id="amazonRegForm"> 
 	<input type="hidden" value="{$simple_path.ref|escape:'htmlall':'UTF-8'}" name="ref" />

--- a/views/templates/front/addresswallet.tpl
+++ b/views/templates/front/addresswallet.tpl
@@ -46,12 +46,16 @@
 jQuery(document).ready(function($) {
 	new OffAmazonPayments.Widgets.AddressBook({
 		sellerId: '{/literal}{$sellerID|escape:'htmlall':'UTF-8'}{literal}',
+		{/literal}{if isset($amz_session) && $amz_session != ''}{literal}amazonOrderReferenceId: '{/literal}{$amz_session|escape:'htmlall':'UTF-8'}{literal}', {/literal}{/if}{literal}
 		onOrderReferenceCreate: function(orderReference) {			
 			 amazonOrderReferenceId = orderReference.getAmazonOrderReferenceId();
 		},
 		onAddressSelect: function(orderReference) {
 			updateAddressSelection(amazonOrderReferenceId);
 		},
+		{/literal}{if isset($widgetreadonly)}{literal}		
+		displayMode: "Read",
+		{/literal}{/if}{literal}
 		design: {
 			designMode: 'responsive'
 		},
@@ -62,6 +66,7 @@ jQuery(document).ready(function($) {
 	}).bind("addressBookWidgetDivBs");
 	new OffAmazonPayments.Widgets.Wallet({
 		sellerId: '{/literal}{$sellerID|escape:'htmlall':'UTF-8'}{literal}',
+		{/literal}{if isset($amz_session) && $amz_session != ''}{literal}amazonOrderReferenceId: '{/literal}{$amz_session|escape:'htmlall':'UTF-8'}{literal}', {/literal}{/if}{literal}
 		design: {
 			designMode: 'responsive'
 		},


### PR DESCRIPTION
- a template fix for payline template
- automatically populate the field custom data of the order
- option to automatically clear the cache on configuration saving
- adding a warning message to ask the user to clear the server cache
- fixing the phone issue on order creation (missing orders)
- fix issue the delivery and billing address change for the standard
checkout
- updates on handling auth-errors
- activation for Austria
- fix for invalid postal codes