### PR TITLE
v2.2.5

### DIFF
--- a/classes/AmazonTransactions.php
+++ b/classes/AmazonTransactions.php
@@ -197,6 +197,21 @@ class AmazonTransactions
         }
         return $response;
     }
+    
+    public static function cancelOrder(AmzPayments $amz_payments, $service, $orderRef)
+    {
+        $orderRefRequest = new OffAmazonPaymentsService_Model_CancelOrderReferenceRequest();
+        $orderRefRequest->setSellerId($amz_payments->merchant_id);
+        $orderRefRequest->setAmazonOrderReferenceId($orderRef);
+        try {
+            $response = $service->cancelOrderReference($orderRefRequest);
+        } catch (OffAmazonPaymentsService_Exception $e) {
+            $amz_paymentsObj = new AmzPayments();
+            $amz_paymentsObj->exceptionLog($e);
+            echo 'ERROR: ' . $e->getMessage();
+        }
+        return $response;
+    }
 
     public static function captureTotalFromAuth(AmzPayments $amz_payments, $service, $auth_id)
     {
@@ -338,6 +353,14 @@ class AmazonTransactions
         if ($oid) {
             $amz_payments = new AmzPayments();
             $new_status = $amz_payments->capture_success_status_id;
+            $order = new Order((int)$oid);
+            $history = $order->getHistory(Context::getContext()->language->id, $amz_payments->capture_success_status_id);
+            if (sizeof($history) > 0) {
+                return false;
+            }
+            if ($order->getCurrentState() == $amz_payments->capture_success_status_id) {
+                return false;
+            }
             self::setOrderStatus($oid, $new_status);
         } else {
             if (! isset(Context::getContext()->cookie->amzSetStatusCaptured)) {
@@ -361,6 +384,9 @@ class AmazonTransactions
                 if (sizeof($history) > 0) {
                     return false;
                 }
+                if ($order->getCurrentState() == $amz_payments->decline_status_id) {
+                    return false;
+                }
             }
             self::setOrderStatus($oid, $new_status);
         }
@@ -372,6 +398,14 @@ class AmazonTransactions
         if ($oid) {
             $amz_payments = new AmzPayments();
             $new_status = $amz_payments->capture_success_status_id;
+            $order = new Order((int)$oid);
+            $history = $order->getHistory(Context::getContext()->language->id, $amz_payments->capture_success_status_id);
+            if (sizeof($history) > 0) {
+                return false;
+            }
+            if ($order->getCurrentState() == $amz_payments->capture_success_status_id) {
+                return false;
+            }
             self::setOrderStatus($oid, $new_status);
         } else {
             if (! isset(Context::getContext()->cookie->amzSetStatusCaptured)) {

--- a/controllers/front/user_to_shop.php
+++ b/controllers/front/user_to_shop.php
@@ -108,11 +108,14 @@ class AmzpaymentsUser_To_ShopModuleFrontController extends ModuleFrontController
                         }
                         
                         $d = self::$amz_payments->requestProfile($accessTokenValue);
+                        self::$amz_payments->recreateAmzJsString();
+                        $this->context->cookie->write();
                         
                         $customer_userid = $d->user_id;
                         $customer_name = $d->name;
                         $customer_email = $d->email;
                         // $postcode = $d->postal_code;
+                        $_POST['psgdpr-consent'] = true;
                         
                         if ($customers_local_id = AmazonPaymentsCustomerHelper::findByAmazonCustomerId($customer_userid)) {
                             // Customer already exists - login

--- a/mails/at/amazon_soft_decline.html
+++ b/mails/at/amazon_soft_decline.html
@@ -11,7 +11,7 @@
       Vielen Dank für Ihre Bestellung Nr. {$ORDER_NR} vom {$ORDER_DATE}.<br />
       <br />
       Leider wurde Ihre Bezahlung von Amazon Pay abgelehnt.<br />
-Sie können unter <a href="https://payments.amazon.de/overview">https://payments.amazon.de/overview</a> die Zahlungsinformationen für Ihre Bestellung aktualisieren, indem Sie eine andere Zahlungsweise auswählen oder eine neue Zahlungsweise eingeben. <br />
+Sie können unter <a href="https://payments.amazon.de/jr/your-account/orders?language=de_DE">https://payments.amazon.de/jr/your-account/orders?language=de_DE</a> die Zahlungsinformationen für Ihre Bestellung aktualisieren, indem Sie eine andere Zahlungsweise auswählen oder eine neue Zahlungsweise eingeben. <br />
 Mit der neuen Zahlungsweise wird dann ein erneuter
 Zahlungsversuch vorgenommen und Sie erhalten eine Bestätigungsemail.<br />
 <br />

--- a/mails/at/amazon_soft_decline.txt
+++ b/mails/at/amazon_soft_decline.txt
@@ -3,6 +3,6 @@ Sehr geehrter Kunde,
 
 Vielen Dank für Ihre Bestellung {$ORDER_NR} vom {$ORDER_DATE}.
 Leider wurde Ihre Bezahlung von Amazon Pay abgelehnt.
-Sie können unter https://payments.amazon.de/overview die Zahlungsinformationen für Ihre Bestellung aktualisieren, indem Sie eine andere Zahlungsweise auswählen oder eine neue Zahlungsweise eingeben.
+Sie können unter https://payments.amazon.de/jr/your-account/orders?language=de_DE die Zahlungsinformationen für Ihre Bestellung aktualisieren, indem Sie eine andere Zahlungsweise auswählen oder eine neue Zahlungsweise eingeben.
 Mit der neuen Zahlungsweise wird dann ein erneuter Zahlungsversuch vorgenommen und Sie erhalten eine Bestätigungsemail.
 

--- a/mails/de/amazon_soft_decline.html
+++ b/mails/de/amazon_soft_decline.html
@@ -11,7 +11,7 @@
       Vielen Dank für Ihre Bestellung Nr. {$ORDER_NR} vom {$ORDER_DATE}.<br />
       <br />
       Leider wurde Ihre Bezahlung von Amazon Pay abgelehnt.<br />
-Sie können unter <a href="https://payments.amazon.de/overview">https://payments.amazon.de/overview</a> die Zahlungsinformationen für Ihre Bestellung aktualisieren, indem Sie eine andere Zahlungsweise auswählen oder eine neue Zahlungsweise eingeben. <br />
+Sie können unter <a href="https://payments.amazon.de/jr/your-account/orders?language=de_DE">https://payments.amazon.de/jr/your-account/orders?language=de_DE</a> die Zahlungsinformationen für Ihre Bestellung aktualisieren, indem Sie eine andere Zahlungsweise auswählen oder eine neue Zahlungsweise eingeben. <br />
 Mit der neuen Zahlungsweise wird dann ein erneuter
 Zahlungsversuch vorgenommen und Sie erhalten eine Bestätigungsemail.<br />
 <br />

--- a/mails/de/amazon_soft_decline.txt
+++ b/mails/de/amazon_soft_decline.txt
@@ -3,6 +3,6 @@ Sehr geehrter Kunde,
 
 Vielen Dank für Ihre Bestellung {$ORDER_NR} vom {$ORDER_DATE}.
 Leider wurde Ihre Bezahlung von Amazon Pay abgelehnt.
-Sie können unter https://payments.amazon.de/overview die Zahlungsinformationen für Ihre Bestellung aktualisieren, indem Sie eine andere Zahlungsweise auswählen oder eine neue Zahlungsweise eingeben.
+Sie können unter https://payments.amazon.de/jr/your-account/orders?language=de_DE die Zahlungsinformationen für Ihre Bestellung aktualisieren, indem Sie eine andere Zahlungsweise auswählen oder eine neue Zahlungsweise eingeben.
 Mit der neuen Zahlungsweise wird dann ein erneuter Zahlungsversuch vorgenommen und Sie erhalten eine Bestätigungsemail.
 

--- a/mails/en/amazon_hard_decline.html
+++ b/mails/en/amazon_hard_decline.html
@@ -8,7 +8,7 @@
 <div style="font-family: Verdana,sans-serif; font-size: 11px;width: 650px;"><a href="{shop_url}"><img alt="{shop_name}" border="0" src="{shop_logo}" title="{shop_name}" /></a><br />
 <strong>Dear customer, </strong><br />
 <br />
-Unfortunately Amazon Pay rejected the payment for your order {$ORDER_NR} from {$ORDER_DATE} in our online shop. Please contact us.
+Unfortunately Amazon Pay declined the payment for your order {$ORDER_NR} from {$ORDER_DATE} in our online shop. Please contact us.
 <br />
 </div>    
 </body>

--- a/mails/en/amazon_soft_decline.html
+++ b/mails/en/amazon_soft_decline.html
@@ -11,7 +11,7 @@
       Thank you for your order {$ORDER_NR} from {$ORDER_DATE}.<br />
       <br />
       Unfortunately your payment was rejected by Amazon Pay.<br />
-You can update the payment information for your order at <a href="https://payments.amazon.co.uk/overview">https://payments.amazon.co.uk/overview</a> by selecting or entering a different payment method. <br />
+You can update the payment information for your order at <a href="https://payments.amazon.co.uk/jr/your-account/orders?language=en_GB">https://payments.amazon.co.uk/jr/your-account/orders?language=en_GB</a> by selecting or entering a different payment method. <br />
 		We will try to authorize the payment again, and you will receive a confirmation email.<br />
 <br />
 </div>

--- a/mails/en/amazon_soft_decline.txt
+++ b/mails/en/amazon_soft_decline.txt
@@ -3,6 +3,6 @@ Dear customer,
 
 Thank you for your order {$ORDER_NR} from {$ORDER_DATE}.
 Unfortunately your payment was rejected by Amazon Pay.
-You can update the payment information for your order at https://payments.amazon.co.uk/overview by selecting or entering a different payment method.
+You can update the payment information for your order at https://payments.amazon.co.uk/jr/your-account/orders?language=de_DE by selecting or entering a different payment method.
 We will try to authorize the payment again, and you will receive a confirmation email.
 

--- a/mails/es/amazon_soft_decline.html
+++ b/mails/es/amazon_soft_decline.html
@@ -11,7 +11,7 @@
       Muchas gracias por tu pedido {$ORDER_NR} de {$ORDER_DATE}.<br />
       <br />
       Desgraciadamente, Amazon Pay ha rechazado tu pago.<br />
-Por favor, dirígete a <a href="https://payments.amazon.es/overview">https://payments.amazon.es/overview</a>  y revisa la información de pago de tu pedido. <br />
+Por favor, dirígete a <a href="https://payments.amazon.es/jr/your-account/orders?language=en_GB">https://payments.amazon.es/jr/your-account/orders?language=en_GB</a>  y revisa la información de pago de tu pedido. <br />
 		Una vez hayas actualizado tu información de pago, solicitaremos automáticamente un nuevo pago en Amazon Pay y recibirás un correo electrónico de confirmación.<br />
 <br />
 </div>

--- a/mails/es/amazon_soft_decline.txt
+++ b/mails/es/amazon_soft_decline.txt
@@ -3,5 +3,5 @@ Saludos,
 
 Muchas gracias por tu pedido {$ORDER_NR} de {$ORDER_DATE}.
 Desgraciadamente, Amazon Pay ha rechazado tu pago.
-Por favor, dirígete a https://payments.amazon.es/overview y revisa la información de pago de tu pedido.
+Por favor, dirígete a https://payments.amazon.es/jr/your-account/orders?language=es_ES y revisa la información de pago de tu pedido.
 Una vez hayas actualizado tu información de pago, solicitaremos automáticamente un nuevo pago en Amazon Pay y recibirás un correo electrónico de confirmación.

--- a/mails/fr/amazon_soft_decline.html
+++ b/mails/fr/amazon_soft_decline.html
@@ -11,7 +11,8 @@
       Merci pour votre commande auprès {$ORDER_NR} de {$ORDER_DATE}.<br />
       <br />
       Malheureusement Amazon Pay n’a pas pu traiter le paiement.<br />
-Veuillez aller sur <a href="https://payments.amazon.fr/overview">https://payments.amazon.fr/overview</a> et mettez à jour les informations de paiement pour votre commande. <br />
+Veuillez aller sur <a href="https://payments.amazon.fr/jr/your-account/orders?language=fr_FR">https://payments.amazon.fr/jr/your-account/orders?language=fr_FR</a> et mettez à jour les informations de paiement pour votre commande. <br />
+Dans la suite une nouvelle demande de paiement va être demandé à Amazon Pay et vous allez recevoir un email de confirmation.
 <br />
 </div>
 </body>

--- a/mails/fr/amazon_soft_decline.txt
+++ b/mails/fr/amazon_soft_decline.txt
@@ -3,5 +3,6 @@ Cher client,
 
 Merci pour votre commande auprès {$ORDER_NR} de {$ORDER_DATE}.
 Malheureusement Amazon Pay n’a pas pu traiter le paiement.
-Veuillez aller sur https://payments.amazon.fr/overview et mettez à jour les informations de paiement pour votre commande.
+Veuillez aller sur https://payments.amazon.fr/jr/your-account/orders?language=fr_FR et mettez à jour les informations de paiement pour votre commande.
+Dans la suite une nouvelle demande de paiement va être demandé à Amazon Pay et vous allez recevoir un email de confirmation.
 

--- a/mails/gb/amazon_hard_decline.html
+++ b/mails/gb/amazon_hard_decline.html
@@ -6,9 +6,9 @@
 </head>
 <body>
 <div style="font-family: Verdana,sans-serif; font-size: 11px;width: 650px;"><a href="{shop_url}"><img alt="{shop_name}" border="0" src="{shop_logo}" title="{shop_name}" /></a><br />
-<strong>Sehr geehrter Kunde, </strong><br />
+<strong>Dear customer, </strong><br />
 <br />
-Leider wurde die Zahlung zu Ihrer Bestellung {$ORDER_NR} vom {$ORDER_DATE} in unserem Onlineshop von Amazon Pay zur&uuml;ckgewiesen. Bitte kontaktieren Sie uns.
+Unfortunately Amazon Pay declined the payment for your order {$ORDER_NR} from {$ORDER_DATE} in our online shop. Please contact us.
 <br />
 </div>    
 </body>

--- a/mails/gb/amazon_hard_decline.txt
+++ b/mails/gb/amazon_hard_decline.txt
@@ -1,5 +1,5 @@
 
-Sehr geehrter Kunde,
+Dear customer,
 
-Leider wurde die Zahlung zu Ihrer Bestellung {$ORDER_NR} vom {$ORDER_DATE} in unserem Onlineshop von Amazon Pay zurückgewiesen. Bitte kontaktieren Sie uns.
+Unfortunately Amazon Pay rejected the payment for your order {$ORDER_NR} from {$ORDER_DATE} in our online shop. Please contact us.
 

--- a/mails/gb/amazon_soft_decline.html
+++ b/mails/gb/amazon_soft_decline.html
@@ -6,14 +6,13 @@
 </head>
 <body>
 <div style="font-family: Verdana,sans-serif; font-size: 11px;width: 650px;"><a href="{shop_url}"><img alt="{shop_name}" border="0" src="{shop_logo}" title="{shop_name}" /></a><br />
-<strong>Sehr geehrter Kunde, </strong><br />
+<strong>Dear customer, </strong><br />
       <br />
-      Vielen Dank für Ihre Bestellung Nr. {$ORDER_NR} vom {$ORDER_DATE}.<br />
+      Thank you for your order {$ORDER_NR} from {$ORDER_DATE}.<br />
       <br />
-      Leider wurde Ihre Bezahlung von Amazon Pay abgelehnt.<br />
-Sie können unter <a href="https://payments.amazon.de/overview">https://payments.amazon.de/overview</a> die Zahlungsinformationen für Ihre Bestellung aktualisieren, indem Sie eine andere Zahlungsweise auswählen oder eine neue Zahlungsweise eingeben. <br />
-Mit der neuen Zahlungsweise wird dann ein erneuter
-Zahlungsversuch vorgenommen und Sie erhalten eine Bestätigungsemail.<br />
+      Unfortunately your payment was rejected by Amazon Pay.<br />
+You can update the payment information for your order at <a href="https://payments.amazon.co.uk/jr/your-account/orders?language=en_GB">https://payments.amazon.co.uk/jr/your-account/orders?language=en_GB</a> by selecting or entering a different payment method. <br />
+		We will try to authorize the payment again, and you will receive a confirmation email.<br />
 <br />
 </div>
 </body>

--- a/mails/gb/amazon_soft_decline.txt
+++ b/mails/gb/amazon_soft_decline.txt
@@ -1,8 +1,8 @@
 
-Sehr geehrter Kunde,
+Dear customer,
 
-Vielen Dank für Ihre Bestellung {$ORDER_NR} vom {$ORDER_DATE}.
-Leider wurde Ihre Bezahlung von Amazon Pay abgelehnt.
-Sie können unter https://payments.amazon.de/overview die Zahlungsinformationen für Ihre Bestellung aktualisieren, indem Sie eine andere Zahlungsweise auswählen oder eine neue Zahlungsweise eingeben.
-Mit der neuen Zahlungsweise wird dann ein erneuter Zahlungsversuch vorgenommen und Sie erhalten eine Bestätigungsemail.
+Thank you for your order {$ORDER_NR} from {$ORDER_DATE}.
+Unfortunately your payment was rejected by Amazon Pay.
+You can update the payment information for your order at https://payments.amazon.co.uk/jr/your-account/orders?language=de_DE by selecting or entering a different payment method.
+We will try to authorize the payment again, and you will receive a confirmation email.
 

--- a/mails/gb/index.php
+++ b/mails/gb/index.php
@@ -1,13 +1,13 @@
 <?php
-/**
-* 2007-2018 PrestaShop
+/*
+* 2007-2014 PrestaShop
 *
 * NOTICE OF LICENSE
 *
-* This source file is subject to the Open Software License (OSL 3.0)
+* This source file is subject to the Academic Free License (AFL 3.0)
 * that is bundled with this package in the file LICENSE.txt.
 * It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/osl-3.0.php
+* http://opensource.org/licenses/afl-3.0.php
 * If you did not receive a copy of the license and are unable to
 * obtain it through the world-wide-web, please send an email
 * to license@prestashop.com so we can send you a copy immediately.
@@ -18,18 +18,18 @@
 * versions in the future. If you wish to customize PrestaShop for your
 * needs please refer to http://www.prestashop.com for more information.
 *
-*  @author    PrestaShop SA <contact@prestashop.com>
-*  @copyright 2007-2018 PrestaShop SA
-*  @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2014 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *  International Registered Trademark & Property of PrestaShop SA
 */
-
+				    	
 header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
 header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-
+						
 header("Cache-Control: no-store, no-cache, must-revalidate");
 header("Cache-Control: post-check=0, pre-check=0", false);
 header("Pragma: no-cache");
-
-header("Location: ../");
+						
+header("Location: ../../");
 exit;

--- a/mails/it/amazon_soft_decline.html
+++ b/mails/it/amazon_soft_decline.html
@@ -11,8 +11,9 @@
       La ringraziamo molto per il suo ordine {$ORDER_NR} de {$ORDER_DATE}.<br />
       <br />
       Purtroppo Amazon Pay ha rifiutato il suo pagamento.<br />
-La preghiamo di andare all‘indirizzo <a href="https://payments.amazon.it/overview">https://payments.amazon.it/overview</a> selezionando un altro metodo di pagamento o inserendone uno nuovo. <br />
-		Una volta inserito il nuovo metodo di pagamento, verrà effettuato un nuovo tentativo di pagamento e inviata un'e-mail di conferma.<br />
+La preghiamo di andare all‘indirizzo <a href="https://payments.amazon.it/jr/your-account/orders?language=it_IT">https://payments.amazon.it/jr/your-account/orders?language=it_IT</a> e aggiornare le informazioni di pagamento per il suo ordine.<br />
+Automaticamente le verrà nuovamente richiesto da Amazon Pay di procedere col pagamento.<br />
+Successivamente riceverà una mail di conferma dell'avvenuto pagamento.<br />
 <br />
 </div>
 </body>

--- a/mails/it/amazon_soft_decline.txt
+++ b/mails/it/amazon_soft_decline.txt
@@ -3,7 +3,8 @@ Gentile Cliente,
 
 La ringraziamo molto per il suo ordine {$ORDER_NR} de {$ORDER_DATE}.
 Purtroppo Amazon Pay ha rifiutato il suo pagamento.
-La preghiamo di andare all‘indirizzo https://payments.amazon.it/overview selezionando un altro metodo di pagamento o inserendone uno nuovo.
-Una volta inserito il nuovo metodo di pagamento, verrà effettuato un nuovo tentativo di pagamento e inviata un'e-mail di conferma.
+La preghiamo di andare all'indirizzo https://payments.amazon.it/jr/your-account/orders?language=it_IT e aggiornare le informazioni di pagamento per il suo ordine.
+Automaticamente le verrà nuovamente richiesto da Amazon Pay di procedere col pagamento.
+Successivamente riceverà una mail di conferma dell'avvenuto pagamento.
 
 

--- a/mails/jp/amazon_hard_decline.html
+++ b/mails/jp/amazon_hard_decline.html
@@ -8,7 +8,7 @@
 <div style="font-family: Verdana,sans-serif; font-size: 11px;width: 650px;"><a href="{shop_url}"><img alt="{shop_name}" border="0" src="{shop_logo}" title="{shop_name}" /></a><br />
 <strong>Dear customer, </strong><br />
 <br />
-Unfortunately Amazon Pay rejected the payment for your order {$ORDER_NR} from {$ORDER_DATE} in our online shop. Please contact us.
+Unfortunately Amazon Pay declined the payment for your order {$ORDER_NR} from {$ORDER_DATE} in our online shop. Please contact us.
 <br />
 </div>    
 </body>

--- a/mails/jp/amazon_soft_decline.html
+++ b/mails/jp/amazon_soft_decline.html
@@ -11,7 +11,7 @@
       Thank you for your order {$ORDER_NR} from {$ORDER_DATE}.<br />
       <br />
       Unfortunately your payment was rejected by Amazon Pay.<br />
-You can update the payment information for your order at <a href="https://payments.amazon.co.uk/overview">https://payments.amazon.co.uk/overview</a> by selecting or entering a different payment method. <br />
+You can update the payment information for your order at <a href="https://payments.amazon.co.uk/jr/your-account/orders?language=en_GB">https://payments.amazon.co.uk/jr/your-account/orders?language=en_GB</a> by selecting or entering a different payment method. <br />
 		We will try to authorize the payment again, and you will receive a confirmation email.<br />
 <br />
 </div>

--- a/mails/jp/amazon_soft_decline.txt
+++ b/mails/jp/amazon_soft_decline.txt
@@ -3,6 +3,6 @@ Dear customer,
 
 Thank you for your order {$ORDER_NR} from {$ORDER_DATE}.
 Unfortunately your payment was rejected by Amazon Pay.
-You can update the payment information for your order at https://payments.amazon.co.uk/overview by selecting or entering a different payment method.
+You can update the payment information for your order at https://payments.amazon.co.uk/jr/your-account/orders?language=de_DE by selecting or entering a different payment method.
 We will try to authorize the payment again, and you will receive a confirmation email.
 

--- a/translations/at.php
+++ b/translations/at.php
@@ -337,3 +337,4 @@ $_MODULE['<{amzpayments}prestashop>payment_ed20689b0d8d53ec534166a88b67f259'] = 
 $_MODULE['<{amzpayments}prestashop>payment_8811becbf523354e20e2017242326f70'] = '(Komfortabel mit Ihrem Amazon-Account bezahlen)';
 $_MODULE['<{amzpayments}prestashop>payment_optype_std_64a985a7c1cdd62470ecddd37d04ebc9'] = 'Jetzt mit Amazon Pay kaufen';
 $_MODULE['<{amzpayments}prestashop>paymentreset_3f350de08883a6ac8983d5400e4fd43b'] = 'Sie haben Amazon Pay gewählt – bitte klicken Sie hier für alternative Zahlungsmethoden';
+$_MODULE['<{amzpayments}prestashop>amzpayments_b7f9430e47eba9941b122f07083a6efa'] = 'Amazon Pay Button über Warenkorb zeigen';

--- a/translations/de.php
+++ b/translations/de.php
@@ -337,3 +337,4 @@ $_MODULE['<{amzpayments}prestashop>payment_ed20689b0d8d53ec534166a88b67f259'] = 
 $_MODULE['<{amzpayments}prestashop>payment_8811becbf523354e20e2017242326f70'] = '(Komfortabel mit Ihrem Amazon-Account bezahlen)';
 $_MODULE['<{amzpayments}prestashop>payment_optype_std_64a985a7c1cdd62470ecddd37d04ebc9'] = 'Jetzt mit Amazon Pay kaufen';
 $_MODULE['<{amzpayments}prestashop>paymentreset_3f350de08883a6ac8983d5400e4fd43b'] = 'Sie haben Amazon Pay gewählt – bitte klicken Sie hier für alternative Zahlungsmethoden';
+$_MODULE['<{amzpayments}prestashop>amzpayments_b7f9430e47eba9941b122f07083a6efa'] = 'Amazon Pay Button über Warenkorb zeigen';

--- a/translations/es.php
+++ b/translations/es.php
@@ -338,3 +338,4 @@ $_MODULE['<{amzpayments}prestashop>payment_ed20689b0d8d53ec534166a88b67f259'] = 
 $_MODULE['<{amzpayments}prestashop>payment_8811becbf523354e20e2017242326f70'] = '(Paga de forma rápida y segura con Amazon Pay)';
 $_MODULE['<{amzpayments}prestashop>payment_optype_std_64a985a7c1cdd62470ecddd37d04ebc9'] = 'Comprar ahora con Amazon Pay';
 $_MODULE['<{amzpayments}prestashop>paymentreset_3f350de08883a6ac8983d5400e4fd43b'] = 'Elegiste Amazon Pay - haz clic aquí si deseas utilizar un método de pago alternativo';
+$_MODULE['<{amzpayments}prestashop>amzpayments_b7f9430e47eba9941b122f07083a6efa'] = 'Mostrar el botón de Amazon Pay en la parte superior de la cesta';

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -339,3 +339,4 @@ $_MODULE['<{amzpayments}prestashop>payment_ed20689b0d8d53ec534166a88b67f259'] = 
 $_MODULE['<{amzpayments}prestashop>payment_8811becbf523354e20e2017242326f70'] = '(Payer en toute sécurité et rapidement en utilisant votre compte Amazon)';
 $_MODULE['<{amzpayments}prestashop>payment_optype_std_64a985a7c1cdd62470ecddd37d04ebc9'] = 'Acheter maintenant avec Amazon Pay';
 $_MODULE['<{amzpayments}prestashop>paymentreset_3f350de08883a6ac8983d5400e4fd43b'] = 'Vous avez choisi Amazon Pay - cliquez ici si vous souhaitez une autre méthode de paiement';
+$_MODULE['<{amzpayments}prestashop>amzpayments_b7f9430e47eba9941b122f07083a6efa'] = 'Afficher le bouton Amazon Pay en haut du panier';

--- a/translations/it.php
+++ b/translations/it.php
@@ -339,3 +339,4 @@ $_MODULE['<{amzpayments}prestashop>payment_ed20689b0d8d53ec534166a88b67f259'] = 
 $_MODULE['<{amzpayments}prestashop>payment_8811becbf523354e20e2017242326f70'] = '(Paga in modo rapido e sicuro con Amazon Pay)';
 $_MODULE['<{amzpayments}prestashop>payment_optype_std_64a985a7c1cdd62470ecddd37d04ebc9'] = 'Compra adesso con Amazon Pay';
 $_MODULE['<{amzpayments}prestashop>paymentreset_3f350de08883a6ac8983d5400e4fd43b'] = 'Hai scelto Amazon Pay - clicca qui se vuoi cambiare modalità di pagamento';
+$_MODULE['<{amzpayments}prestashop>amzpayments_b7f9430e47eba9941b122f07083a6efa'] = 'Mostra il bottone Amazon Pay sopra il carrello';

--- a/upgrade/upgrade-2.2.4.php
+++ b/upgrade/upgrade-2.2.4.php
@@ -19,11 +19,15 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
-/**
- * @deprecated This file is just for backward compatibility!
- */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
 
-$_GET['module'] = 'amzpayments';
-$_GET['controller'] = 'cron';
-$_GET['fc'] = 'module';
-require_once('../../index.php');
+function upgrade_module_2_2_4($module)
+{
+    $old_value = Configuration::get('ENVIRONMENT');
+    Configuration::updateValue('AMZ_ENVIRONMENT', $old_value);
+    $module->registerHook('displayBeforeShoppingCartBlock');
+    $module->registerHook('actionCustomerLogoutAfter');
+    return true;
+}

--- a/views/css/admin.css
+++ b/views/css/admin.css
@@ -45,7 +45,9 @@
 #missingerror {
 	display: none;
 }
-
+#returnedurl {
+	margin-left: 45px;
+}
 .grouping {
 	font-weight: bold;
 	padding-left: 11px;

--- a/views/css/amzpayments.css
+++ b/views/css/amzpayments.css
@@ -74,6 +74,10 @@ body#module-amzpayments-amzpayments .delivery_option label {
 body#module-amzpayments-amzpayments .delivery_option label {
 	margin-left: 20px;
 }
+body#module-amzpayments-amzpayments .delivery_option_logo img {
+	width: auto;
+	max-height: 100px;
+}
 
 #amzOverlay {
 	position: absolute;
@@ -125,7 +129,7 @@ input.disabled {
 	text-align: center;
 	margin-bottom: 5px;
 }
-
+#payWithAmazonDivAbove,
 #payWithAmazonDiv {
 	float: right;
 	margin-bottom: 4px;
@@ -281,3 +285,55 @@ p.amzpay_reset {
 #addressMissings .additional_field {
 	border: 2px solid orange;
 }
+
+#submitAddress.button.button-medium {
+  font-size: 17px;
+  line-height: 21px;
+  color: #fff;
+  padding: 0;
+  font-weight: bold;
+  background: #43b754;
+  background-image: -webkit-gradient(linear, left 0%, left 100%, from(#43b754), to(#42ac52));
+  background-image: -webkit-linear-gradient(top, #43b754, 0%, #42ac52, 100%);
+  background-image: -moz-linear-gradient(top, #43b754 0%, #42ac52 100%);
+  background-image: linear-gradient(to bottom, #43b754 0%, #42ac52 100%);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#FF43B754', endColorstr='#FF42AC52', GradientType=0);
+  border: 1px solid;
+  border-color: #399a49 #247f32 #1a6d27 #399a49;
+  -moz-border-radius: 0;
+  -webkit-border-radius: 0;
+  border-radius: 0; }
+  #submitAddress.button.button-medium span {
+    display: block;
+    padding: 10px 10px 10px 14px;
+    border: 1px solid;
+    border-color: #74d578; }
+    @media (max-width: 480px) {
+      #submitAddress.button.button-medium span {
+        font-size: 15px;
+        padding-right: 7px;
+        padding-left: 7px; } }
+    #submitAddress.button.button-medium span i.left {
+      font-size: 24px;
+      vertical-align: -2px;
+      margin: -4px 10px 0 0;
+      display: inline-block; }
+      @media (max-width: 480px) {
+        #submitAddress.button.button-medium span i.left {
+          margin-right: 5px; } }
+    #submitAddress.button.button-medium span i.right {
+      margin-right: 0;
+      margin-left: 9px; }
+      @media (max-width: 480px) {
+        #submitAddress.button.button-medium span i.right {
+          margin-left: 5px; } }
+  #submitAddress.button.button-medium:hover {
+    background: #3aa04c;
+    background-image: -webkit-gradient(linear, left 0%, left 100%, from(#3aa04c), to(#3aa04a));
+    background-image: -webkit-linear-gradient(top, #3aa04c, 0%, #3aa04a, 100%);
+    background-image: -moz-linear-gradient(top, #3aa04c 0%, #3aa04a 100%);
+    background-image: linear-gradient(to bottom, #3aa04c 0%, #3aa04a 100%);
+    background-repeat: repeat-x;
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#FF3AA04C', endColorstr='#FF3AA04A', GradientType=0);
+    border-color: #196f28 #399a49 #399a49 #258033; }

--- a/views/js/admin.js
+++ b/views/js/admin.js
@@ -181,7 +181,7 @@ $(document).ready(function(){
 	    	$('#videojavascriptorigins').toggle();
 	    });
 	    
-	    $(".showvideoreturnurls").click(function() {
+	    $(".showvideoreturnurls, #showvideoreturnurls2").click(function() {
 	    	$(this).closest('div').find('.videoreturnurls').toggle();
 	    });
 	    

--- a/views/js/amzpayments_checkout.js
+++ b/views/js/amzpayments_checkout.js
@@ -120,211 +120,253 @@ function updateCarrierList(json)
 
 function updateAddressSelection(amazonOrderReferenceId)
 {
-	var idAddress_delivery = 0;
-	var idAddress_invoice = idAddress_delivery;
+	var redirectURL = LOGINREDIRECTAMZ;	
+	options = { scope: 'payments:widget', popup: true, interactive: 'never' };
+	amazon.Login.authorize(options, function(response) {
+		if (response.error) { 
+			loginOptions =  {scope: 'profile postal_code payments:widget payments:shipping_address payments:billing_address', popup: !useRedirect, state: '&toCheckout=1' };
+			amazon.Login.authorize (loginOptions, (useRedirect ? redirectURL : function(response) {
+				jQuery.ajax({
+		    				type: 'GET',
+		            	    url: REDIRECTAMZ,
+		                	data: 'ajax=true&method=setsession&access_token=' + response.access_token,
+			                success: function(htmlcontent){
+			                  	window.location = REDIRECTAMZ + amazonOrderReferenceId;
+			                }
+				});
+			})
+			);
+			return false;
+		} else {
+			var idAddress_delivery = 0;
+			var idAddress_invoice = idAddress_delivery;
 
-	var additional_fields = '';
-	$("#addressMissings .additional_field").each(function() {
-		additional_fields += '&add[' + $(this).attr("name") + ']=' + $(this).val();		
-	});	
-	
-	$('#opc_account-overlay').fadeIn('slow');
-	$('#opc_delivery_methods-overlay').fadeIn('slow');
-	$('#opc_payment_methods-overlay').fadeIn('slow');
-	
-	$.ajax({
-		type: 'POST',
-		headers: { "cache-control": "no-cache" },
-		url: REDIRECTAMZ + '&rand=' + new Date().getTime(),
-		async: true,
-		cache: false,
-		dataType : "json",
-		data: 'amazonOrderReferenceId=' + amazonOrderReferenceId + '&allow_refresh=1&ajax=true&method=updateAddressesSelected&id_address_delivery=' + idAddress_delivery + '&id_address_invoice=' + idAddress_invoice + '&token=' + static_token + additional_fields,
-		success: function(jsonData)
-		{
-			if (jsonData.hasError)
-			{
-				var errors = '';
-				for(var error in jsonData.errors)
-					if(error !== 'indexOf')
-						errors += $('<div />').html(jsonData.errors[error]).text() + "\n";
-				alert(errors);
-				
-				if (jsonData.fields_html) {
-					$("#addressMissings").empty();
-					$("#addressMissings").html(jsonData.fields_html);
-					$("#addressMissings").fadeIn();
-					$("#submitAddress").fadeIn();
-					$("#submitAddress").unbind('click').on('click', function() { updateAddressSelection(amazonOrderReferenceId); });
-				}				
-				$("#amz_execute_order").attr("disabled","disabled").addClass("disabled"); 
-				$('#amzOverlay, #opc_delivery_methods-overlay, #opc_payment_methods-overlay').fadeOut('slow');
-			}
-			else
-			{
-				$("#submitAddress").fadeOut('fast', function() { $("#addressMissings").empty(); checkCGV(); });
-				$("#addressMissings").fadeOut();
-				if (jsonData.refresh)
-					location.reload();
-				
-				try {
-					$('#cart_summary .address_'+deliveryAddress).each(function() {
-						$(this)
-							.removeClass('address_'+deliveryAddress)
-							.addClass('address_'+idAddress_delivery);
-						$(this).attr('id', $(this).attr('id').replace(/_\d+$/, '_'+idAddress_delivery));
-						if ($(this).find('.cart_unit span').length > 0 && $(this).find('.cart_unit span').attr('id') !== undefined && $(this).find('.cart_unit span').attr('id').length > 0)
-							$(this).find('.cart_unit span').attr('id', $(this).find('.cart_unit span').attr('id').replace(/_\d+$/, '_'+idAddress_delivery));
-	
-						if ($(this).find('.cart_total span').length > 0&& $(this).find('.cart_total span').attr('id') !== undefined && $(this).find('.cart_total span').attr('id').length > 0)
-							$(this).find('.cart_total span').attr('id', $(this).find('.cart_total span').attr('id').replace(/_\d+$/, '_'+idAddress_delivery));
-	
-						if ($(this).find('.cart_quantity_input').length > 0 && $(this).find('.cart_quantity_input').attr('id') !== undefined && $(this).find('.cart_quantity_input').attr('name').length > 0)
+			var additional_fields = '';
+			$("#addressMissings .additional_field").each(function() {
+				additional_fields += '&add[' + $(this).attr("name") + ']=' + $(this).val();		
+			});	
+			
+			$('#opc_account-overlay').fadeIn('slow');
+			$('#opc_delivery_methods-overlay').fadeIn('slow');
+			$('#opc_payment_methods-overlay').fadeIn('slow');
+			
+			$.ajax({
+				type: 'POST',
+				headers: { "cache-control": "no-cache" },
+				url: REDIRECTAMZ + '&rand=' + new Date().getTime(),
+				async: true,
+				cache: false,
+				dataType : "json",
+				data: 'amazonOrderReferenceId=' + amazonOrderReferenceId + '&allow_refresh=1&ajax=true&method=updateAddressesSelected&id_address_delivery=' + idAddress_delivery + '&id_address_invoice=' + idAddress_invoice + '&token=' + static_token + additional_fields,
+				success: function(jsonData)
+				{
+					if (jsonData.hasError)
+					{
+						var errors = '';
+						for(var error in jsonData.errors)
+							if(error !== 'indexOf')
+								errors += $('<div />').html(jsonData.errors[error]).text() + "\n";
+						alert(errors);
+						
+						if (jsonData.fields_html) {
+							$("#addressMissings").empty();
+							$("#addressMissings").html(jsonData.fields_html);
+							$("#addressMissings").fadeIn();
+							$("#submitAddress").fadeIn();
+							$("#submitAddress").unbind('click').on('click', function() { updateAddressSelection(amazonOrderReferenceId); });
+						}				
+						$("#amz_execute_order").attr("disabled","disabled").addClass("disabled"); 
+						$('#amzOverlay, #opc_delivery_methods-overlay, #opc_payment_methods-overlay').fadeOut('slow');
+					}
+					else
+					{
+						$("#submitAddress").fadeOut('fast', function() { $("#addressMissings").empty(); checkCGV(); });
+						$("#addressMissings").fadeOut();
+						if (jsonData.refresh)
+							location.reload();
+						
+						try {
+							$('#cart_summary .address_'+deliveryAddress).each(function() {
+								$(this)
+									.removeClass('address_'+deliveryAddress)
+									.addClass('address_'+idAddress_delivery);
+								$(this).attr('id', $(this).attr('id').replace(/_\d+$/, '_'+idAddress_delivery));
+								if ($(this).find('.cart_unit span').length > 0 && $(this).find('.cart_unit span').attr('id') !== undefined && $(this).find('.cart_unit span').attr('id').length > 0)
+									$(this).find('.cart_unit span').attr('id', $(this).find('.cart_unit span').attr('id').replace(/_\d+$/, '_'+idAddress_delivery));
+			
+								if ($(this).find('.cart_total span').length > 0&& $(this).find('.cart_total span').attr('id') !== undefined && $(this).find('.cart_total span').attr('id').length > 0)
+									$(this).find('.cart_total span').attr('id', $(this).find('.cart_total span').attr('id').replace(/_\d+$/, '_'+idAddress_delivery));
+			
+								if ($(this).find('.cart_quantity_input').length > 0 && $(this).find('.cart_quantity_input').attr('id') !== undefined && $(this).find('.cart_quantity_input').attr('name').length > 0)
+								{
+									var name = $(this).find('.cart_quantity_input').attr('name')+'_hidden';
+									$(this).find('.cart_quantity_input').attr('name', $(this).find('.cart_quantity_input').attr('name').replace(/_\d+$/, '_'+idAddress_delivery));
+									if ($(this).find('[name='+name+']').length > 0)
+										$(this).find('[name='+name+']').attr('name', name.replace(/_\d+_hidden$/, '_'+idAddress_delivery+'_hidden'));
+								}
+			
+								if ($(this).find('.cart_quantity_delete').length > 0 && $(this).find('.cart_quantity_delete').attr('id') !== undefined && $(this).find('.cart_quantity_delete').attr('id').length > 0)
+								{
+									$(this).find('.cart_quantity_delete')
+										.attr('id', $(this).find('.cart_quantity_delete').attr('id').replace(/_\d+$/, '_'+idAddress_delivery))
+										.attr('href', $(this).find('.cart_quantity_delete').attr('href').replace(/id_address_delivery=\d+&/, 'id_address_delivery='+idAddress_delivery+'&'));
+								}
+								
+								if ($(this).find('.cart_quantity_down').length > 0 && $(this).find('.cart_quantity_down').attr('id') !== undefined && $(this).find('.cart_quantity_down').attr('id').length > 0)
+								{
+									$(this).find('.cart_quantity_down')
+										.attr('id', $(this).find('.cart_quantity_down').attr('id').replace(/_\d+$/, '_'+idAddress_delivery))
+										.attr('href', $(this).find('.cart_quantity_down').attr('href').replace(/id_address_delivery=\d+&/, 'id_address_delivery='+idAddress_delivery+'&'));
+								}
+			
+								if ($(this).find('.cart_quantity_up').length > 0 && $(this).find('.cart_quantity_up').attr('id') !== undefined && $(this).find('.cart_quantity_up').attr('id').length > 0)
+								{
+									$(this).find('.cart_quantity_up')
+										.attr('id', $(this).find('.cart_quantity_up').attr('id').replace(/_\d+$/, '_'+idAddress_delivery))
+										.attr('href', $(this).find('.cart_quantity_up').attr('href').replace(/id_address_delivery=\d+&/, 'id_address_delivery='+idAddress_delivery+'&'));
+								}	
+							});
+						} catch(err) { }
+
+						deliveryAddress = idAddress_delivery;
+						if (window.ajaxCart !== undefined)
 						{
-							var name = $(this).find('.cart_quantity_input').attr('name')+'_hidden';
-							$(this).find('.cart_quantity_input').attr('name', $(this).find('.cart_quantity_input').attr('name').replace(/_\d+$/, '_'+idAddress_delivery));
-							if ($(this).find('[name='+name+']').length > 0)
-								$(this).find('[name='+name+']').attr('name', name.replace(/_\d+_hidden$/, '_'+idAddress_delivery+'_hidden'));
-						}
-	
-						if ($(this).find('.cart_quantity_delete').length > 0 && $(this).find('.cart_quantity_delete').attr('id') !== undefined && $(this).find('.cart_quantity_delete').attr('id').length > 0)
-						{
-							$(this).find('.cart_quantity_delete')
-								.attr('id', $(this).find('.cart_quantity_delete').attr('id').replace(/_\d+$/, '_'+idAddress_delivery))
-								.attr('href', $(this).find('.cart_quantity_delete').attr('href').replace(/id_address_delivery=\d+&/, 'id_address_delivery='+idAddress_delivery+'&'));
+							$('#cart_block_list dd, #cart_block_list dt').each(function(){
+								if (typeof($(this).attr('id')) != 'undefined')
+									$(this).attr('id', $(this).attr('id').replace(/_\d+$/, '_' + idAddress_delivery));
+							});
 						}
 						
-						if ($(this).find('.cart_quantity_down').length > 0 && $(this).find('.cart_quantity_down').attr('id') !== undefined && $(this).find('.cart_quantity_down').attr('id').length > 0)
-						{
-							$(this).find('.cart_quantity_down')
-								.attr('id', $(this).find('.cart_quantity_down').attr('id').replace(/_\d+$/, '_'+idAddress_delivery))
-								.attr('href', $(this).find('.cart_quantity_down').attr('href').replace(/id_address_delivery=\d+&/, 'id_address_delivery='+idAddress_delivery+'&'));
+						if (typeof updateAddressId === "function") {
+							first_item = $("#cart_summary .cart_item ");
+							if (first_item.length > 0) {
+								if (first_item.hasClass('address_' + jsonData.summary.delivery.id)) {
+								} else {
+									$(".cart_item").each(
+											function() {
+												if ($(this).attr("id").indexOf('product_') > -1) {
+													var ids = $(this).attr('id').split('_');
+													var id_product = ids[1];
+													var id_product_attribute = ids[2];
+													var old_id_address_delivery = ids[4];
+													var new_id_address_delivery = jsonData.summary.delivery.id;											
+													var line = $(this);
+													updateAddressId(id_product, id_product_attribute, old_id_address_delivery, new_id_address_delivery);
+												}
+											}
+										);
+								}
+							}
 						}
-	
-						if ($(this).find('.cart_quantity_up').length > 0 && $(this).find('.cart_quantity_up').attr('id') !== undefined && $(this).find('.cart_quantity_up').attr('id').length > 0)
-						{
-							$(this).find('.cart_quantity_up')
-								.attr('id', $(this).find('.cart_quantity_up').attr('id').replace(/_\d+$/, '_'+idAddress_delivery))
-								.attr('href', $(this).find('.cart_quantity_up').attr('href').replace(/id_address_delivery=\d+&/, 'id_address_delivery='+idAddress_delivery+'&'));
-						}	
-					});
-				} catch(err) { }
-
-				deliveryAddress = idAddress_delivery;
-				if (window.ajaxCart !== undefined)
-				{
-					$('#cart_block_list dd, #cart_block_list dt').each(function(){
-						if (typeof($(this).attr('id')) != 'undefined')
-							$(this).attr('id', $(this).attr('id').replace(/_\d+$/, '_' + idAddress_delivery));
-					});
-				}
-				
-				if (typeof updateAddressId === "function") {
-					first_item = $("#cart_summary .cart_item ");
-					if (first_item.length > 0) {
-						if (first_item.hasClass('address_' + jsonData.summary.delivery.id)) {
-						} else {
-							$(".cart_item").each(
-									function() {
-										if ($(this).attr("id").indexOf('product_') > -1) {
-											var ids = $(this).attr('id').split('_');
-											var id_product = ids[1];
-											var id_product_attribute = ids[2];
-											var old_id_address_delivery = ids[4];
-											var new_id_address_delivery = jsonData.summary.delivery.id;											
-											var line = $(this);
-											updateAddressId(id_product, id_product_attribute, old_id_address_delivery, new_id_address_delivery);
-										}
-									}
-								);
+						
+						updateCarrierList(jsonData.carrier_data);
+						if (typeof amazonCarrierErrorMessage !== 'undefined' || amazonCarrierErrorMessage !== null) {
+							if ($("#noCarrierWarning").length > 0) {
+								$("#noCarrierWarning").hide();
+								$("#noCarrierWarning").html(amazonCarrierErrorMessage);
+								$("#noCarrierWarning").show();
+							}
 						}
+						updateCartSummary(jsonData.summary);
+						updateHookShoppingCart(jsonData.HOOK_SHOPPING_CART);
+						updateHookShoppingCartExtra(jsonData.HOOK_SHOPPING_CART_EXTRA);
+						if ($('#gift-price').length == 1)
+							$('#gift-price').html(jsonData.gift_price);
+						checkCGV();
+						$('#amzOverlay, #opc_account-overlay, #opc_delivery_methods-overlay, #opc_payment_methods-overlay').fadeOut('slow');
 					}
+				},
+				error: function(XMLHttpRequest, textStatus, errorThrown) {
+					if (textStatus !== 'abort')
+						alert("TECHNICAL ERROR: unable to save adresses \n\nDetails:\nError thrown: " + XMLHttpRequest + "\n" + 'Text status: ' + textStatus);
+					$('#amzOverlay, #opc_account-overlay, #opc_delivery_methods-overlay, #opc_payment_methods-overlay').fadeOut('slow');
 				}
-				
-				updateCarrierList(jsonData.carrier_data);
-				if (typeof amazonCarrierErrorMessage !== 'undefined' || amazonCarrierErrorMessage !== null) {
-					if ($("#noCarrierWarning").length > 0) {
-						$("#noCarrierWarning").hide();
-						$("#noCarrierWarning").html(amazonCarrierErrorMessage);
-						$("#noCarrierWarning").show();
-					}
-				}
-				updateCartSummary(jsonData.summary);
-				updateHookShoppingCart(jsonData.HOOK_SHOPPING_CART);
-				updateHookShoppingCartExtra(jsonData.HOOK_SHOPPING_CART_EXTRA);
-				if ($('#gift-price').length == 1)
-					$('#gift-price').html(jsonData.gift_price);
-				checkCGV();
-				$('#amzOverlay, #opc_account-overlay, #opc_delivery_methods-overlay, #opc_payment_methods-overlay').fadeOut('slow');
-			}
-		},
-		error: function(XMLHttpRequest, textStatus, errorThrown) {
-			if (textStatus !== 'abort')
-				alert("TECHNICAL ERROR: unable to save adresses \n\nDetails:\nError thrown: " + XMLHttpRequest + "\n" + 'Text status: ' + textStatus);
-			$('#amzOverlay, #opc_account-overlay, #opc_delivery_methods-overlay, #opc_payment_methods-overlay').fadeOut('slow');
+			});			
+			
 		}
 	});
+	
 }
 
 $("#amz_execute_order").live('click', function() {
 	
 	$('#amzOverlay').fadeIn('slow');
 	
-	var connectRequest = '';
-	if ($("#connect_amz_account").length > 0) {
-		if ($("#connect_amz_account").is(':checked') || $("#connect_amz_account").attr("type") == 'hidden') {
-			connectRequest = '&connect_amz_account=' + $("#connect_amz_account").val();
-		}
-	}
+	var redirectURL = LOGINREDIRECTAMZ;	
 	
-	$.ajax({
-		type: 'POST',
-		headers: { "cache-control": "no-cache" },
-		url: REDIRECTAMZ + '?rand=' + new Date().getTime(),
-		async: true,
-		cache: false,
-		dataType : "json",
-		data: 'amazonOrderReferenceId=' + amazonOrderReferenceId + '&allow_refresh=1&ajax=true&method=executeOrder&confirm=1&token=' + static_token + connectRequest,
-		success: function(jsonData)
-		{
-			if (jsonData.hasError)
-			{
-				var errors = '';
-				for(var error in jsonData.errors)
-
-					if(error !== 'indexOf')
-						errors += $('<div />').html(jsonData.errors[error]).text() + "\n";
-				alert(errors);
-				
-				if (typeof jsonData.redirection !== 'undefined') {
-					if (jsonData.redirection.length > 0) {
-						window.location.href = jsonData.redirection;
-						return;
-					}
-				}
-				$('#amzOverlay, #opc_delivery_methods-overlay, #opc_payment_methods-overlay').fadeOut('slow');
-				$("form#voucher, .ajax_cart_block_remove_link, .cart_quantity_up, .cart_quantity_down, .cart_quantity_delete").remove();
-				
-				$("#opc_delivery_methods-overlay").css("height", $("#opc_delivery_methods").outerHeight()).css("width",  $("#opc_delivery_methods").outerWidth()).css("background", "none repeat scroll 0 0 rgba(99, 99, 99, 0.5)").css("position","absolute").css("z-index","1000").fadeIn();
-				$("#amz_execute_order").attr("disabled","disabled").addClass("disabled"); 
-				$('#gift, .delivery_option_radio, #recyclable').click(function(){
-				    return false;
+	options = { scope: 'payments:widget', popup: true, interactive: 'never' };
+	amazon.Login.authorize(options, function(response) {
+		if (response.error) { 
+			loginOptions =  {scope: 'profile postal_code payments:widget payments:shipping_address payments:billing_address', popup: !useRedirect, state: '&toCheckout=1' };
+			amazon.Login.authorize (loginOptions, (useRedirect ? redirectURL : function(response) {
+				jQuery.ajax({
+		    				type: 'GET',
+		            	    url: REDIRECTAMZ,
+		                	data: 'ajax=true&method=setsession&access_token=' + response.access_token,
+			                success: function(htmlcontent){
+			                  	window.location = REDIRECTAMZ + amazonOrderReferenceId;
+			                }
 				});
-				reCreateWalletWidget();
-				reCreateAddressBookWidget();
+			})
+			);
+			return false;
+		} else {
+			var connectRequest = '';
+			if ($("#connect_amz_account").length > 0) {
+				if ($("#connect_amz_account").is(':checked') || $("#connect_amz_account").attr("type") == 'hidden') {
+					connectRequest = '&connect_amz_account=' + $("#connect_amz_account").val();
+				}
 			}
-			else
-			{
-				window.location.href = jsonData.redirection;
-			}
-		},
-		error: function(XMLHttpRequest, textStatus, errorThrown) {
-			if (textStatus !== 'abort')
-				alert("TECHNICAL ERROR: unable to save adresses \n\nDetails:\nError thrown: " + XMLHttpRequest + "\n" + 'Text status: ' + textStatus);
-			$('#amzOverlay, #opc_account-overlay, #opc_delivery_methods-overlay, #opc_payment_methods-overlay').fadeOut('slow');
+			
+			$.ajax({
+				type: 'POST',
+				headers: { "cache-control": "no-cache" },
+				url: REDIRECTAMZ + '?rand=' + new Date().getTime(),
+				async: true,
+				cache: false,
+				dataType : "json",
+				data: 'amazonOrderReferenceId=' + amazonOrderReferenceId + '&allow_refresh=1&ajax=true&method=executeOrder&confirm=1&token=' + static_token + connectRequest,
+				success: function(jsonData)
+				{
+					if (jsonData.hasError)
+					{
+						var errors = '';
+						for(var error in jsonData.errors)
+
+							if(error !== 'indexOf')
+								errors += $('<div />').html(jsonData.errors[error]).text() + "\n";
+						alert(errors);
+						
+						if (typeof jsonData.redirection !== 'undefined') {
+							if (jsonData.redirection.length > 0) {
+								window.location.href = jsonData.redirection;
+								return;
+							}
+						}
+						$('#amzOverlay, #opc_delivery_methods-overlay, #opc_payment_methods-overlay').fadeOut('slow');
+						$("form#voucher, .ajax_cart_block_remove_link, .cart_quantity_up, .cart_quantity_down, .cart_quantity_delete").remove();
+						
+						$("#opc_delivery_methods-overlay").css("height", $("#opc_delivery_methods").outerHeight()).css("width",  $("#opc_delivery_methods").outerWidth()).css("background", "none repeat scroll 0 0 rgba(99, 99, 99, 0.5)").css("position","absolute").css("z-index","1000").fadeIn();
+						$("#amz_execute_order").attr("disabled","disabled").addClass("disabled"); 
+						$('#gift, .delivery_option_radio, #recyclable').click(function(){
+						    return false;
+						});
+						reCreateWalletWidget();
+						reCreateAddressBookWidget();
+					}
+					else
+					{
+						window.location.href = jsonData.redirection;
+					}
+				},
+				error: function(XMLHttpRequest, textStatus, errorThrown) {
+					if (textStatus !== 'abort')
+						alert("TECHNICAL ERROR: unable to save adresses \n\nDetails:\nError thrown: " + XMLHttpRequest + "\n" + 'Text status: ' + textStatus);
+					$('#amzOverlay, #opc_account-overlay, #opc_delivery_methods-overlay, #opc_payment_methods-overlay').fadeOut('slow');
+				}
+			});	
 		}
-	});	
-	
+	});		
 	
 });
 

--- a/views/js/amzpayments_login.js
+++ b/views/js/amzpayments_login.js
@@ -50,8 +50,9 @@ function initAmazon(){
 	   			amzBtnColor = AMZ_BUTTON_COLOR_LPA_NAVI;
 	   		var redirectURL = LOGINREDIRECTAMZ;
 	   		var redirectToCheckout = false;
+	   		var redirectState = '';
 	   		if ($(this).attr("id") == "jsLoginAuthPage" && location.href.indexOf('display_guest_checkout') > 1) {
-	   			redirectURL = LOGINREDIRECTAMZ_CHECKOUT;
+	   			redirectState = '&toCheckout=1';
 	   			redirectToCheckout = true;
 	   		}
 	        OffAmazonPayments.Button($(this).attr('id'), AMZSELLERID, {
@@ -60,7 +61,7 @@ function initAmazon(){
 	                color: amzBtnColor,
 	                language: AMZ_WIDGET_LANGUAGE,
 	                authorization: function() {
-	                loginOptions =  {scope: 'profile postal_code payments:widget payments:shipping_address payments:billing_address', popup: !useRedirect };
+	                loginOptions =  {scope: 'profile postal_code payments:widget payments:shipping_address payments:billing_address', popup: !useRedirect, state: redirectState };
 	                authRequest = amazon.Login.authorize (loginOptions, useRedirect ? redirectURL : null);
 	            },    
 	            onSignIn: function(orderReference) {
@@ -89,7 +90,7 @@ function initAmazon(){
 	}
 	if (LPA_MODE == 'login_pay' || LPA_MODE == 'pay') {
 		if($('#payWithAmazonDiv').length > 0){
-			bindCartButton('payWithAmazonDiv');		   
+			bindCartButton('payWithAmazonDiv');
 		}
 		if ($('#button_order_cart').length > 0 && $('#amz_cart_widgets_summary').length == 0) {
 			$('#button_order_cart').before('<div id="payWithAmazonCartDiv" class="' + (AMZ_CREATE_ACCOUNT_EXP == '1' ? 'amz_create_account' : null) + '"></div>');
@@ -142,14 +143,19 @@ function checkForAmazonListButton() {
 
 function bindCartButton(div_id) {
 	if (jQuery('#' + div_id).attr('data-is-set') != '1') {
-		    OffAmazonPayments.Button(div_id, AMZSELLERID, {
+		var redirectState = '';
+   		var redirectURL = LOGINREDIRECTAMZ;
+		if (useRedirect) {
+			redirectState = '&toCheckout=1';
+		}		
+		OffAmazonPayments.Button(div_id, AMZSELLERID, {
 	            type: AMZ_BUTTON_TYPE_PAY,
 	            size: AMZ_BUTTON_SIZE_LPA,
 	            color: AMZ_BUTTON_COLOR_LPA,
 	            language: AMZ_WIDGET_LANGUAGE,
 	            authorization: function() {
-	            loginOptions =  {scope: 'profile postal_code payments:widget payments:shipping_address payments:billing_address', popup: !useRedirect };
-	            authRequest = amazon.Login.authorize (loginOptions, (useRedirect ? LOGINREDIRECTAMZ_CHECKOUT : null));
+	            loginOptions =  {scope: 'profile postal_code payments:widget payments:shipping_address payments:billing_address', popup: !useRedirect, state: redirectState };
+	            authRequest = amazon.Login.authorize (loginOptions, (useRedirect ? redirectURL : null));
 	        },
 	        onSignIn: function(orderReference) {
 	            amazonOrderReferenceId = orderReference.getAmazonOrderReferenceId();
@@ -181,7 +187,7 @@ function bindCartButton(div_id) {
 	            console.log(error); 
 	        }
 	    });
-			setTipr('#' + div_id);
+		setTipr('#' + div_id);
 	    jQuery('#' + div_id).attr('data-is-set', '1');
 	}	
 }

--- a/views/templates/admin/configuration.tpl
+++ b/views/templates/admin/configuration.tpl
@@ -478,8 +478,8 @@
 					<a style="cursor: pointer;" target="_blank" href="https://sellercentral-europe.amazon.com/home?cor=mmd_EU">
 						{l s='Enter these URLs in your Amazon Pay account' mod='amzpayments'}
 					</a>
-					<a style="color:#FF9900;cursor: pointer;" aria-hidden="true" data-toggle="modal" data-target="#myModal2"><i class="fa fa-eye" aria-hidden="true"></i> {l s='See instructions' mod='amzpayments'}</a>
-					<a style="color:#FF9900;cursor: pointer;" id="showvideonotification" title="{l s='Watch our video' mod='amzpayments'}"><i class="fa fa-file-video-o" aria-hidden="true"></i> {l s='Watch our video' mod='amzpayments'}</a>
+					<a style="color:#FF9900;cursor: pointer;" aria-hidden="true" data-toggle="modal" data-target="#myModal5"><i class="fa fa-eye" aria-hidden="true"></i> {l s='See instructions' mod='amzpayments'}</a>
+					<a style="color:#FF9900;cursor: pointer;" id="showvideoreturnurls2" title="{l s='Watch our video' mod='amzpayments'}"><i class="fa fa-file-video-o" aria-hidden="true"></i> {l s='Watch our video' mod='amzpayments'}</a>
 					<br />
 					{foreach from=$allowed_return_url_1 item=aru}
 						{$aru|escape:'htmlall':'UTF-8'}<br />		
@@ -487,6 +487,12 @@
 					{foreach from=$allowed_return_url_2 item=aru}
 						{$aru|escape:'htmlall':'UTF-8'}<br />		
 					{/foreach}
+					
+					<div class="videoreturnurls" style="width: 80%; clear: both">
+    	       			<video controls="controls" style="max-width: 100%;">
+							<source src="{$videodir|escape:'html':'UTF-8'}{$langdir|escape:'html':'UTF-8'}/ReturnURLs{$langdir|escape:'html':'UTF-8'|strtoupper}.mp4" type="video/webm" />
+						</video>
+					</div>  
 				</div>
 				
 				<div id="grouping_states" style="display: none">

--- a/views/templates/front/addresswallet.tpl
+++ b/views/templates/front/addresswallet.tpl
@@ -48,6 +48,27 @@
 {literal}
 <script>
 jQuery(document).ready(function($) {
+
+	var redirectURL = LOGINREDIRECTAMZ;	
+
+	options = { scope: 'payments:widget', popup: true, interactive: 'never' };
+	amazon.Login.authorize(options, function(response) {
+		if (response.error) { 
+			loginOptions =  {scope: 'profile postal_code payments:widget payments:shipping_address payments:billing_address', popup: !useRedirect, state: '' };
+			amazon.Login.authorize (loginOptions, (useRedirect ? redirectURL : function(response) {
+				jQuery.ajax({
+		    				type: 'GET',
+		            	    url: REDIRECTAMZ,
+		                	data: 'ajax=true&method=setsession&access_token=' + response.access_token,
+			                success: function(htmlcontent){
+			                  	location.reload();
+			                }
+				});
+			})
+			);
+		}
+	});
+
 	new OffAmazonPayments.Widgets.AddressBook({
 		sellerId: '{/literal}{$sellerID|escape:'htmlall':'UTF-8'}{literal}',
 		{/literal}{if isset($amz_session) && $amz_session != ''}{literal}amazonOrderReferenceId: '{/literal}{$amz_session|escape:'htmlall':'UTF-8'}{literal}', {/literal}{/if}{literal}

--- a/views/templates/front/amzpayments.tpl
+++ b/views/templates/front/amzpayments.tpl
@@ -61,6 +61,24 @@ var amazonOrderReferenceId = '{/literal}{$amz_session|escape:'htmlall':'UTF-8'}{
 jQuery(document).ready(function($) {
 	var amzAddressSelectCounter = 0;
 	
+	options = { scope: 'payments:widget', popup: true, interactive: 'never' };
+	amazon.Login.authorize(options, function(response) {
+		if (response.error) { 
+			loginOptions =  {scope: 'profile postal_code payments:widget payments:shipping_address payments:billing_address', popup: !useRedirect, state: '&toCheckout=1' };
+			amazon.Login.authorize (loginOptions, (useRedirect ? redirectURL : function(response) {
+				jQuery.ajax({
+		    				type: 'GET',
+		            	    url: REDIRECTAMZ,
+		                	data: 'ajax=true&method=setsession&access_token=' + response.access_token,
+			                success: function(htmlcontent){
+			                  	window.location = REDIRECTAMZ + amazonOrderReferenceId;
+			                }
+				});
+			})
+			);
+		}
+	});	
+	
 	new OffAmazonPayments.Widgets.AddressBook({
 		sellerId: '{/literal}{$sellerID|escape:'htmlall':'UTF-8'}{literal}',
 		{/literal}{if $amz_session == ''}{literal}

--- a/views/templates/front/amzpayments_bs.tpl
+++ b/views/templates/front/amzpayments_bs.tpl
@@ -67,6 +67,26 @@ var amazonOrderReferenceId = '{/literal}{$amz_session|escape:'htmlall':'UTF-8'}{
 jQuery(document).ready(function($) {
 	var amzAddressSelectCounter = 0;
 	
+	var redirectURL = LOGINREDIRECTAMZ;	
+	
+	options = { scope: 'payments:widget', popup: true, interactive: 'never' };
+	amazon.Login.authorize(options, function(response) {
+		if (response.error) { 
+			loginOptions =  {scope: 'profile postal_code payments:widget payments:shipping_address payments:billing_address', popup: !useRedirect, state: '&toCheckout=1' };
+			amazon.Login.authorize (loginOptions, (useRedirect ? redirectURL : function(response) {
+				jQuery.ajax({
+		    				type: 'GET',
+		            	    url: REDIRECTAMZ,
+		                	data: 'ajax=true&method=setsession&access_token=' + response.access_token,
+			                success: function(htmlcontent){
+			                  	window.location = REDIRECTAMZ + amazonOrderReferenceId;
+			                }
+				});
+			})
+			);
+		}
+	});		
+	
 	new OffAmazonPayments.Widgets.AddressBook({
 		sellerId: '{/literal}{$sellerID|escape:'htmlall':'UTF-8'}{literal}',
 		{/literal}{if $amz_session == ''}{literal}

--- a/views/templates/front/process_login.tpl
+++ b/views/templates/front/process_login.tpl
@@ -11,11 +11,20 @@
 <script>
 {literal}
 var accessToken = getURLParameter("access_token", $(location).attr('href'));
+var state = getURLParameter("state", $(location).attr('href'));
+if (state == '&toCheckout=1') {
+	toCheckout = '&action=checkout';
+}
+{/literal}
+{if $toCheckout}
+toCheckout = '&action=checkout';
+{/if}
+{literal}
 $(document).ready(function() {	
     $.ajax({
 		type: 'GET',
 		url: SETUSERAJAX,
-		data: 'ajax=true{/literal}{if $toCheckout}&action=checkout{/if}{if $fromCheckout}&action=fromCheckout{/if}{literal}&method=setusertoshop&access_token=' + accessToken,
+		data: 'ajax=true' + toCheckout + '{/literal}{if $fromCheckout}&action=fromCheckout{/if}{literal}&method=setusertoshop&access_token=' + accessToken,
 		success: function(htmlcontent) {
 			if (htmlcontent == 'error') {
 				alert('An error occured - please try again or contact our support');

--- a/views/templates/front/select_address.tpl
+++ b/views/templates/front/select_address.tpl
@@ -40,6 +40,25 @@
 {literal}
 <script>
 jQuery(document).ready(function($) {
+
+	options = { scope: 'payments:widget', popup: true, interactive: 'never' };
+	amazon.Login.authorize(options, function(response) {
+		if (response.error) { 
+			loginOptions =  {scope: 'profile postal_code payments:widget payments:shipping_address payments:billing_address', popup: !useRedirect, state: '' };
+			amazon.Login.authorize (loginOptions, (useRedirect ? redirectURL : function(response) {
+				jQuery.ajax({
+		    				type: 'GET',
+		            	    url: REDIRECTAMZ,
+		                	data: 'ajax=true&method=setsession&access_token=' + response.access_token,
+			                success: function(htmlcontent){
+			                  	location.reload();
+			                }
+				});
+			})
+			);
+		}
+	});
+
 	new OffAmazonPayments.Widgets.AddressBook({
 		sellerId: '{/literal}{$sellerID|escape:'htmlall':'UTF-8'}{literal}',
 		onOrderReferenceCreate: function(orderReference) {			

--- a/views/templates/hooks/amzpayments_above.tpl
+++ b/views/templates/hooks/amzpayments_above.tpl
@@ -1,0 +1,14 @@
+{*
+* Amazon Advanced Payment APIs Modul
+* for Support please visit www.patworx.de
+*
+*  @author patworx multimedia GmbH <service@patworx.de>
+*  In collaboration with alkim media
+*  @copyright  2013-2015 patworx multimedia GmbH
+*  @license    Released under the GNU General Public License
+*}
+<div id="payWithAmazonMainDivAbove"{if $hide_button} style="display:none;"{/if}>
+	<div id="payWithAmazonDivAbove" class="{if $create_account}amz_create_account{/if}">
+	</div>
+</div>
+{literal}<script> bindCartButton('payWithAmazonDivAbove'); </script>{/literal}


### PR DESCRIPTION
- Add the possibility to do synchronous authorisation with asynchronous
fall-back
- Trigger the authentication when Amazon Pay cookie are expired or
missing
- Reduce the number of redirection links by 2
- Create an option to add the Amazon Pay button above the basket
- Remove the option “Logo Only”
- Order Cancellation via IPN
- Fix duplicate order status
- Fix  to improve the compatibility with the module KnowBand – One Page
Checkout